### PR TITLE
refactor: Rebase IsoformMapper on vite + Chakra v3 master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ yarn-debug.log*
 yarn-error.log*
 
 .idea
+.claude/
 public/data
 
 .tsbuildinfo-node

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "alluvial",
+  "name": "isoformmapper",
   "version": "1.14.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "alluvial",
+      "name": "isoformmapper",
       "version": "1.14.1",
       "dependencies": {
         "@chakra-ui/react": "^3.35.0",
@@ -16,6 +16,7 @@
         "@mapequation/infomap-parser": "^1.0.2",
         "@mapequation/infomap-react": "^1.0.0",
         "@tanstack/react-table": "^8.21.3",
+        "biomsa": "^0.3.3",
         "d3": "^7.9.0",
         "file-saver": "^2.0.5",
         "framer-motion": "^12.38.0",
@@ -26,6 +27,7 @@
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
         "react-dropzone": "^15.0.0",
+        "react-force-graph-3d": "^1.29.1",
         "react-icons": "^5.6.0",
         "recharts": "^3.8.1",
         "title-case": "^4.3.2"
@@ -2165,6 +2167,12 @@
         }
       }
     },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "25.0.0",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-25.0.0.tgz",
+      "integrity": "sha512-XKLA6syeBUaPzx4j3qwMqzzq+V4uo72BnlbOjmuljLrRqdsd3qnzvZZoxvMHZ23ndsRS4aufU6JOZYpCbU6T1A==",
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
@@ -3652,6 +3660,31 @@
       "integrity": "sha512-XUpqDtXfHe7CySjOhLPLj9H8rxbiFUJAGgmBzNdpsGPP4wx12cpOXrpSjRXZ2kMwooMPz/P7RPDBteto8sqhAQ==",
       "license": "MIT"
     },
+    "node_modules/3d-force-graph": {
+      "version": "1.80.0",
+      "resolved": "https://registry.npmjs.org/3d-force-graph/-/3d-force-graph-1.80.0.tgz",
+      "integrity": "sha512-tzI353gW1nXPpnC7VTa3JjMg+3cp77qOLUFO0vucPTfF+q5R6sQsNsIqVTbRIb7RSypn14nBa4yfkOe9ThxASw==",
+      "license": "MIT",
+      "dependencies": {
+        "accessor-fn": "1",
+        "kapsule": "^1.16",
+        "three": ">=0.179 <1",
+        "three-forcegraph": "1",
+        "three-render-objects": "^1.41"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/accessor-fn": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/accessor-fn/-/accessor-fn-1.5.3.tgz",
+      "integrity": "sha512-rkAofCwe/FvYFUlMB0v0gWmhqtfAtV1IUkdPbfhTUyYniu5LrC0A0UJkTH0Jv3S8SvwkmfuAlY+mQIJATdocMA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/add-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/add-stream/-/add-stream-1.0.0.tgz",
@@ -3779,6 +3812,12 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/biomsa": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/biomsa/-/biomsa-0.3.3.tgz",
+      "integrity": "sha512-SmpIwTMBE0JKAo18OHCWvIaUcrjKvED/opAltSFhHVx9Pz9j5HcWSHNhUvaU1o3AKDT5NVrWgc0Amp0OJRe+2w==",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.14",
@@ -4478,6 +4517,12 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-binarytree": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/d3-binarytree/-/d3-binarytree-1.0.2.tgz",
+      "integrity": "sha512-cElUNH+sHu95L04m92pG73t2MEJXKu+GeKUN1TJkFsu93E5W8E9Sc3kHEGJKgenGvj19m6upSn2EunvMgMD2Yw==",
+      "license": "MIT"
+    },
     "node_modules/d3-brush": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
@@ -4621,6 +4666,22 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-force-3d": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/d3-force-3d/-/d3-force-3d-3.0.6.tgz",
+      "integrity": "sha512-4tsKHUPLOVkyfEffZo1v6sFHvGFwAIIjt/W8IThbp08DYAsXZck+2pSHEG5W1+gQgEvFLdZkYvmJAbRM2EzMnA==",
+      "license": "MIT",
+      "dependencies": {
+        "d3-binarytree": "1",
+        "d3-dispatch": "1 - 3",
+        "d3-octree": "1",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-format": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
@@ -4662,6 +4723,12 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/d3-octree": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/d3-octree/-/d3-octree-1.1.0.tgz",
+      "integrity": "sha512-F8gPlqpP+HwRPMO/8uOu5wjH110+6q4cgJvgJT6vlpy3BEaDIKlTZrgHKZSp/i1InRpVfh4puY/kvL6MxK930A==",
+      "license": "MIT"
     },
     "node_modules/d3-path": {
       "version": "3.1.0",
@@ -4826,6 +4893,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/data-bind-mapper": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/data-bind-mapper/-/data-bind-mapper-1.0.3.tgz",
+      "integrity": "sha512-QmU3lyEnbENQPo0M1F9BMu4s6cqNNp8iJA+b/HP2sSb7pf3dxwF3+EP1eO69rwBfH9kFJ1apmzrtogAmVt2/Xw==",
+      "license": "MIT",
+      "dependencies": {
+        "accessor-fn": "1"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/data-urls": {
@@ -5378,6 +5457,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/float-tooltip": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/float-tooltip/-/float-tooltip-1.7.5.tgz",
+      "integrity": "sha512-/kXzuDnnBqyyWyhDMH7+PfP8J/oXiAavGzcRxASOMRHFuReDtofizLLJsf7nnDLAfEaMW4pVWaXrAjtnglpEkg==",
+      "license": "MIT",
+      "dependencies": {
+        "d3-selection": "2 - 3",
+        "kapsule": "^1.16",
+        "preact": "10"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/form-data": {
@@ -5955,6 +6048,15 @@
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "license": "MIT"
     },
+    "node_modules/jerrypick": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/jerrypick/-/jerrypick-1.1.2.tgz",
+      "integrity": "sha512-YKnxXEekXKzhpf7CLYA0A+oDP8V0OhICNCr5lv96FvSsDEmrb0GKM776JgQvHTMjr7DTTPEVv/1Ciaw0uEWzBA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -6085,6 +6187,18 @@
         "pako": "~1.0.2",
         "readable-stream": "~2.3.6",
         "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/kapsule": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/kapsule/-/kapsule-1.16.3.tgz",
+      "integrity": "sha512-4+5mNNf4vZDSwPhKprKwz3330iisPrb08JyMgbsdFrimBCKNHecua/WBwvVg3n7vwx0C1ARjfhwIpbrbd9n5wg==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash-es": "4"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/kind-of": {
@@ -6452,6 +6566,12 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "license": "MIT"
     },
     "node_modules/lodash.ismatch": {
@@ -6898,6 +7018,44 @@
         "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
+    "node_modules/ngraph.events": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ngraph.events/-/ngraph.events-1.4.0.tgz",
+      "integrity": "sha512-NeDGI4DSyjBNBRtA86222JoYietsmCXbs8CEB0dZ51Xeh4lhVl1y3wpWLumczvnha8sFQIW4E0vvVWwgmX2mGw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/ngraph.forcelayout": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/ngraph.forcelayout/-/ngraph.forcelayout-3.3.1.tgz",
+      "integrity": "sha512-MKBuEh1wujyQHFTW57y5vd/uuEOK0XfXYxm3lC7kktjJLRdt/KEKEknyOlc6tjXflqBKEuYBBcu7Ax5VY+S6aw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "ngraph.events": "^1.0.0",
+        "ngraph.merge": "^1.0.0",
+        "ngraph.random": "^1.0.0"
+      }
+    },
+    "node_modules/ngraph.graph": {
+      "version": "20.1.2",
+      "resolved": "https://registry.npmjs.org/ngraph.graph/-/ngraph.graph-20.1.2.tgz",
+      "integrity": "sha512-W/G3GBR3Y5UxMLHTUCPP9v+pbtpzwuAEIqP5oZV+9IwgxAIEZwh+Foc60iPc1idlnK7Zxu0p3puxAyNmDvBd0Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "ngraph.events": "^1.4.0"
+      }
+    },
+    "node_modules/ngraph.merge": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ngraph.merge/-/ngraph.merge-1.0.0.tgz",
+      "integrity": "sha512-5J8YjGITUJeapsomtTALYsw7rFveYkM+lBj3QiYZ79EymQcuri65Nw3knQtFxQBU1r5iOaVRXrSwMENUPK62Vg==",
+      "license": "MIT"
+    },
+    "node_modules/ngraph.random": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ngraph.random/-/ngraph.random-1.2.0.tgz",
+      "integrity": "sha512-4EUeAGbB2HWX9njd6bP6tciN6ByJfoaAvmVL9QTaZSeXrW46eNGA9GajiXiPBbvFqxUWFkEbyo6x5qsACUuVfA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/node-releases": {
       "version": "2.0.44",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.44.tgz",
@@ -7165,6 +7323,18 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/polished": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/polished/-/polished-4.3.1.tgz",
+      "integrity": "sha512-OBatVyC/N7SCW/FaDHrSd+vn0o5cS855TOmYi4OkdWUMSJCET/xip//ch8xGUvtr3i44X9LVyWwQlRMTN3pwSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.17.8"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.14",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
@@ -7192,6 +7362,16 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.29.1",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.1.tgz",
+      "integrity": "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
       }
     },
     "node_modules/prettier": {
@@ -7355,6 +7535,23 @@
         "react": ">= 16.8 || 18.0.0"
       }
     },
+    "node_modules/react-force-graph-3d": {
+      "version": "1.29.1",
+      "resolved": "https://registry.npmjs.org/react-force-graph-3d/-/react-force-graph-3d-1.29.1.tgz",
+      "integrity": "sha512-5Vp+PGpYnO+zLwgK2NvNqdXHvsWLrFzpDfJW1vUA1twjo9SPvXqfUYQrnRmAbD+K2tOxkZw1BkbH31l5b4TWHg==",
+      "license": "MIT",
+      "dependencies": {
+        "3d-force-graph": "^1.79",
+        "prop-types": "15",
+        "react-kapsule": "^2.5"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "node_modules/react-icons": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.6.0.tgz",
@@ -7370,6 +7567,21 @@
       "integrity": "sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/react-kapsule": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/react-kapsule/-/react-kapsule-2.5.7.tgz",
+      "integrity": "sha512-kifAF4ZPD77qZKc4CKLmozq6GY1sBzPEJTIJb0wWFK6HsePJatK3jXplZn2eeAt3x67CDozgi7/rO8fNQ/AL7A==",
+      "license": "MIT",
+      "dependencies": {
+        "jerrypick": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      }
     },
     "node_modules/react-redux": {
       "version": "9.3.0",
@@ -8125,6 +8337,56 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/three": {
+      "version": "0.184.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.184.0.tgz",
+      "integrity": "sha512-wtTRjG92pM5eUg/KuUnHsqSAlPM296brTOcLgMRqEeylYTh/CdtvKUvCyyCQTzFuStieWxvZb8mVTMvdPyUpxg==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/three-forcegraph": {
+      "version": "1.43.4",
+      "resolved": "https://registry.npmjs.org/three-forcegraph/-/three-forcegraph-1.43.4.tgz",
+      "integrity": "sha512-FtmiZP/T16ZQaHza3JDaDn0YTXFtg9e7pGnTeU8nzu0NNkx7MpWbF/GvmpbQsWHx3rukHtkRv1fTorLPB3FDEA==",
+      "license": "MIT",
+      "dependencies": {
+        "accessor-fn": "1",
+        "d3-array": "1 - 3",
+        "d3-force-3d": "2 - 3",
+        "d3-scale": "1 - 4",
+        "d3-scale-chromatic": "1 - 3",
+        "data-bind-mapper": "1",
+        "kapsule": "^1.16",
+        "ngraph.forcelayout": "3",
+        "ngraph.graph": "20",
+        "tinycolor2": "1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "three": ">=0.118.3"
+      }
+    },
+    "node_modules/three-render-objects": {
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/three-render-objects/-/three-render-objects-1.42.0.tgz",
+      "integrity": "sha512-KYfkPrYGEbIK8ChFocWqOF1aAN80FBUBWVYB8mB2oBpVuVN+52FvvngVYB5ieFANQu7Rt21rPYZ/xKaAgVWWRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tweenjs/tween.js": "18 - 25",
+        "accessor-fn": "1",
+        "float-tooltip": "^1.7",
+        "kapsule": "^1.16",
+        "polished": "4"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "three": ">=0.179"
+      }
+    },
     "node_modules/through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -8168,6 +8430,12 @@
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
       "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinycolor2": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
+      "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
       "license": "MIT"
     },
     "node_modules/tinyexec": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "alluvial",
+  "name": "isoformmapper",
   "version": "1.14.1",
   "private": true,
   "type": "module",
@@ -12,6 +12,7 @@
     "@mapequation/infomap-parser": "^1.0.2",
     "@mapequation/infomap-react": "^1.0.0",
     "@tanstack/react-table": "^8.21.3",
+    "biomsa": "^0.3.3",
     "d3": "^7.9.0",
     "file-saver": "^2.0.5",
     "framer-motion": "^12.38.0",
@@ -22,6 +23,7 @@
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "react-dropzone": "^15.0.0",
+    "react-force-graph-3d": "^1.29.1",
     "react-icons": "^5.6.0",
     "recharts": "^3.8.1",
     "title-case": "^4.3.2"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   workers: 1,
   reporter: "list",
   use: {
-    baseURL: "http://localhost:5173/alluvial/",
+    baseURL: "http://localhost:5174/isoformmapper/",
     trace: "off",
   },
   projects: [
@@ -16,8 +16,8 @@ export default defineConfig({
   ],
   webServer: {
     command: "npm run dev",
-    url: "http://localhost:5173/alluvial/",
-    reuseExistingServer: !process.env.CI,
+    url: "http://localhost:5174/isoformmapper/",
+    reuseExistingServer: true,
     stdout: "ignore",
     stderr: "pipe",
   },

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,78 +1,22 @@
 import { Box } from "@chakra-ui/react";
-import { motion } from "framer-motion";
 import { observer } from "mobx-react";
-import { useContext, useState } from "react";
-import useEventListener from "../hooks/useEventListener";
-import { StoreContext } from "../store";
-import Diagram from "./Diagram";
-import Documentation from "./Documentation";
-import LoadNetworks from "./LoadNetworks";
+import { useState } from "react";
+import IsoformApp from "./isoform/IsoformApp";
 import Logo from "./Logo";
 import NodeList from "./NodeList";
-import Sidebar from "./Sidebar";
 import { useColorModeValue } from "./ui/color-mode";
 import { DialogRoot } from "./ui/dialog";
 
 export const drawerWidth = 350;
 
 export default observer(function App() {
-  const store = useContext(StoreContext);
   const bg = useColorModeValue("white", "var(--chakra-colors-gray-900)");
-  const [isLoadOpen, setIsLoadOpen] = useState(true);
-  const [isHelpOpen, setIsHelpOpen] = useState(false);
   const [isExplorerOpen, setIsExplorerOpen] = useState(false);
 
-  const onLoadClose = () => setIsLoadOpen(false);
-  const onHelpClose = () => setIsHelpOpen(false);
   const onExplorerClose = () => setIsExplorerOpen(false);
-
-  const openLoad = () => {
-    setIsLoadOpen(true);
-    onHelpClose();
-    onExplorerClose();
-  };
-
-  const openHelp = () => {
-    setIsHelpOpen(true);
-    onLoadClose();
-    onExplorerClose();
-  };
-
-  const openExplorer = () => {
-    setIsExplorerOpen(true);
-    onLoadClose();
-    onHelpClose();
-  };
-
-  useEventListener("keydown", (event) => {
-    // @ts-ignore
-    const key = event?.key;
-    if (!store.editMode && key === "l") {
-      openLoad();
-    }
-  });
 
   return (
     <>
-      <DialogRoot
-        size="xl"
-        placement="center"
-        open={isLoadOpen}
-        onOpenChange={(e) => !e.open && onLoadClose()}
-      >
-        <LoadNetworks onClose={onLoadClose} />
-      </DialogRoot>
-
-      <DialogRoot
-        size="xl"
-        scrollBehavior="inside"
-        placement="center"
-        open={isHelpOpen}
-        onOpenChange={(e) => !e.open && onHelpClose()}
-      >
-        <Documentation onClose={onHelpClose} />
-      </DialogRoot>
-
       <DialogRoot
         size="xl"
         placement="center"
@@ -82,44 +26,24 @@ export default observer(function App() {
         {isExplorerOpen && <NodeList onClose={onExplorerClose} />}
       </DialogRoot>
 
-      <Diagram />
-
-      <motion.div
-        initial={false}
-        animate={{ y: isLoadOpen ? 0 : "-100%" }}
-        transition={{ duration: 0.2, ease: "easeOut" }}
-        style={{
-          position: "fixed",
-          top: 0,
-          left: 0,
-          right: 0,
-          height: "6rem",
-          zIndex: 1500,
-        }}
+      <Box
+        position="fixed"
+        top={0}
+        left={0}
+        right={0}
+        height="6rem"
+        bg={bg}
+        zIndex={1500}
+        borderBottom="1px solid"
+        borderColor="gray.200"
+        px={10}
+        display="flex"
+        alignItems="center"
       >
-        <Box px={10} display="flex" alignItems="center" h="6rem" bg={bg}>
-          <Logo long />
-        </Box>
-      </motion.div>
+        <Logo showVersion />
+      </Box>
 
-      <motion.div
-        initial={false}
-        animate={{ x: !isLoadOpen ? 0 : "100%" }}
-        transition={{ duration: 0.2, ease: "easeOut" }}
-        style={{
-          position: "fixed",
-          top: 0,
-          right: 0,
-          width: drawerWidth,
-          height: "100vh",
-        }}
-      >
-        <Sidebar
-          onLoadClick={openLoad}
-          onAboutClick={openHelp}
-          onModuleViewClick={openExplorer}
-        />
-      </motion.div>
+      <IsoformApp />
     </>
   );
 });

--- a/src/components/Diagram/Diagram.tsx
+++ b/src/components/Diagram/Diagram.tsx
@@ -14,9 +14,17 @@ import SelectedModule from "./SelectedModule";
 
 const zoom = d3.zoom<SVGSVGElement, unknown>().scaleExtent([0.1, 1000]);
 
-export default observer(function Diagram() {
+export default observer(function Diagram({
+  width: widthProp,
+  height: heightProp,
+}: {
+  width?: number;
+  height?: number;
+} = {}) {
   const ref = useRef<SVGSVGElement>(null);
-  const { width, height } = useWindowSize();
+  const window = useWindowSize();
+  const width = widthProp ?? window.width;
+  const height = heightProp ?? window.height;
   const store = useContext(StoreContext);
   const { diagram, defaultHighlightColor, highlightColors, updateFlag } = store;
   const fillColor = highlightColor(defaultHighlightColor, highlightColors);
@@ -87,7 +95,7 @@ export default observer(function Diagram() {
         <motion.g
           id="translate-center"
           initial={false}
-          animate={translateCenter(diagram)}
+          animate={translateCenter(diagram, { width, height }, !!widthProp)}
           transition={{ duration: 0.2, bounce: 0 }}
         >
           {diagram.children.map((network) => (
@@ -100,12 +108,26 @@ export default observer(function Diagram() {
   );
 });
 
-function translateCenter({ width, height }: { width: number; height: number }) {
+type BoxSize = { width: number; height: number };
+
+function translateCenter(
+  diagram: BoxSize,
+  box: BoxSize,
+  fitToBox: boolean,
+) {
+  if (fitToBox) {
+    const spaceX = box.width - diagram.width;
+    const spaceY = box.height - diagram.height;
+    const x = Math.max(spaceX / 2, 10);
+    const y = Math.max(spaceY / 2, 10);
+    return { x, y };
+  }
+
   let { innerWidth, innerHeight } = window;
   innerWidth -= drawerWidth;
 
-  const x = Math.max((innerWidth - width) / 2, 100);
-  const y = Math.max((innerHeight - height) / 3, 100);
+  const x = Math.max((innerWidth - diagram.width) / 2, 100);
+  const y = Math.max((innerHeight - diagram.height) / 3, 100);
 
   return { x, y };
 }

--- a/src/components/Diagram/Tooltip/Tooltip.tsx
+++ b/src/components/Diagram/Tooltip/Tooltip.tsx
@@ -2,6 +2,10 @@ import { Tooltip as ChakraTooltip, Portal } from "@chakra-ui/react";
 import { PropsWithChildren } from "react";
 import ModuleTooltip from "./ModuleTooltip";
 
+// Chakra v3's tooltip defaults to a dark/inverted surface. The diagram is on
+// a light canvas and the inner chart Box is white, so the dark frame reads as
+// an out-of-place black slab. Override to a light surface with a subtle
+// border, matching the rest of the app's neutral light palette.
 export default function Tooltip({
   children,
   ...props
@@ -11,9 +15,29 @@ export default function Tooltip({
       <ChakraTooltip.Trigger asChild>{children}</ChakraTooltip.Trigger>
       <Portal>
         <ChakraTooltip.Positioner>
-          <ChakraTooltip.Content shadow="xl" borderRadius="sm">
-            <ChakraTooltip.Arrow>
-              <ChakraTooltip.ArrowTip />
+          <ChakraTooltip.Content
+            bg="white"
+            color="gray.800"
+            borderRadius="md"
+            borderWidth="1px"
+            borderColor="gray.200"
+            shadow="lg"
+            p={0}
+            maxW="none"
+          >
+            <ChakraTooltip.Arrow
+              css={{
+                "--arrow-background": "white",
+                "--arrow-size": "8px",
+              }}
+            >
+              <ChakraTooltip.ArrowTip
+                css={{
+                  borderTop: "1px solid",
+                  borderLeft: "1px solid",
+                  borderColor: "var(--chakra-colors-gray-200)",
+                }}
+              />
             </ChakraTooltip.Arrow>
             <ModuleTooltip {...props} />
           </ChakraTooltip.Content>

--- a/src/components/General/SelectButtonGroup.tsx
+++ b/src/components/General/SelectButtonGroup.tsx
@@ -1,0 +1,56 @@
+import { Group, GroupProps } from "@chakra-ui/react";
+import React from "react";
+
+// Match the v2 look: active button reads as "outlined" (transparent bg with a
+// visible gray border) while inactive buttons read as "filled" gray. Both
+// keep a clearly different hover state so the affordance is unambiguous.
+//
+// NOTE: pseudo selectors (`_hover`, `_active`) are passed as top-level props
+// rather than nested in `css`. Chakra v3 merges recipe variants and component
+// pseudo props at the same specificity, and the `css` prop's nested
+// `_hover` was being overridden by the outline-variant recipe's own
+// `_hover` — leaving inactive buttons visually inert on hover. Top-level
+// props win.
+const activeProps = {
+  bg: "transparent",
+  color: "gray.800",
+  borderColor: "gray.200",
+  _hover: { bg: "gray.50" },
+};
+
+const inactiveProps = {
+  bg: "gray.100",
+  color: "gray.700",
+  borderColor: "gray.100",
+  _hover: { bg: "gray.200", borderColor: "gray.200" },
+  _active: { bg: "gray.300" },
+};
+
+interface SelectButtonGroupProps extends GroupProps {
+  onChangeSelected: (value: string | number) => void;
+  value: string | number;
+  children: React.ReactElement<any>[];
+}
+
+export const SelectButtonGroup: React.FC<SelectButtonGroupProps> = (props) => {
+  const { value, onChangeSelected, children, ...groupProps } = props;
+  return (
+    <Group attached {...groupProps}>
+      {React.Children.map(children, (Child) => {
+        const isActive = value === Child.props?.value;
+        return React.cloneElement(Child, {
+          variant: "outline",
+          onClick: () => {
+            if (isActive) return;
+            onChangeSelected(Child.props?.value);
+          },
+          "aria-pressed": isActive,
+          transition: "background-color 0.12s ease, border-color 0.12s ease",
+          ...(isActive ? activeProps : inactiveProps),
+        });
+      })}
+    </Group>
+  );
+};
+
+export default SelectButtonGroup;

--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -1,19 +1,20 @@
 import { HStack } from "@chakra-ui/react";
+import Infomap from "@mapequation/infomap";
 import { useColorModeValue } from "./ui/color-mode";
 import ToggleColorMode from "./ToggleColorMode";
 
-export default function Logo({ showVersion = false, long = false }) {
+export default function Logo({ showVersion = false }) {
   const color = useColorModeValue("hsl(0, 0%, 33%)", "hsl(0, 0%, 60%)");
   const brand = useColorModeValue("hsl(0, 68%, 42%)", "hsl(0, 68%, 62%)");
 
   return (
     <HStack w="100%" justify="space-between" align="center">
       <HStack justify="flex-start" align="center" gap={3}>
-        <a href="//mapequation.org">
+        <a href="//mapequation.org" aria-label="mapequation.org">
           <img
             alt=""
-            width="32px"
-            height="32px"
+            width="32"
+            height="32"
             src="//www.mapequation.org/assets/img/twocolormapicon_whiteboarder.svg"
           />
         </a>
@@ -25,15 +26,17 @@ export default function Logo({ showVersion = false, long = false }) {
               fontSize: "1.4em",
             }}
           >
-            <span style={{ color: brand }}>Alluvial</span>
-            <span style={{ color }}> Diagram</span>
-            {long && <span style={{ color }}> Generator</span>}
+            <span style={{ color: brand }}>Isoform</span>
+            <span style={{ color }}>Mapper</span>
           </span>
           {showVersion && (
             <span style={{ color }}>
               {" v" + import.meta.env.VITE_APP_VERSION}
             </span>
           )}
+          <div style={{ marginTop: -4, fontSize: "0.75em", color }}>
+            Powered by Infomap v{Infomap.__version__}
+          </div>
         </div>
       </HStack>
       <ToggleColorMode />

--- a/src/components/isoform/AlignSequences.tsx
+++ b/src/components/isoform/AlignSequences.tsx
@@ -1,0 +1,88 @@
+import {
+  Box,
+  Button,
+  Code,
+  Flex,
+  Text,
+  chakra,
+} from "@chakra-ui/react";
+import { useContext } from "react";
+import { StoreContext } from "../../store";
+import { getAAColor } from "../../store/PdbStore";
+import { observer } from "mobx-react";
+
+export default observer(function AlignSequences({}: {}) {
+  const store = useContext(StoreContext);
+  const { alignment, isoforms } = store.input;
+
+  return (
+    <Flex
+      className="step-heading"
+      direction="column"
+      alignItems="center"
+      mb={1}
+    >
+      <Text color="gray.600" mt={2} maxW="640px" textAlign="center">
+        Calculate a sequence alignment so corresponding amino acids share
+        identifiers across isoforms.
+      </Text>
+
+      <Flex direction="column" alignItems="center" mt={4}>
+        <Button
+          type="button"
+          disabled={!store.input.canGenerateAlignment}
+          onClick={store.input.generateAlignment}
+        >
+          Align Sequences
+        </Button>
+
+        {alignment.length > 0 && (
+          <Box overflowX="auto" maxW={800} mt={6}>
+            {alignment.map(({ name, sequence }) => (
+              <Code
+                key={`${name}-code`}
+                display="block"
+                whiteSpace="nowrap"
+                py={1}
+              >
+                {[...sequence].map((c, i) => (
+                  <span
+                    key={`${name}-code[${i}]`}
+                    title={`${i + 1}_${c}`}
+                    style={{
+                      backgroundColor: c === "-" ? "#eeeeee" : getAAColor(c),
+                    }}
+                  >
+                    {c}
+                  </span>
+                ))}
+              </Code>
+            ))}
+          </Box>
+        )}
+        {alignment.length > 0 && (
+          <Box mt={3}>
+            <Text
+              fontSize="sm"
+              color="gray.600"
+              style={{ fontVariantNumeric: "tabular-nums" }}
+            >
+              Amino acids — isoform 1:{" "}
+              <chakra.span fontWeight={600} color="gray.800">
+                {isoforms[0].sequence?.code.length ?? 0}
+              </chakra.span>
+              , isoform 2:{" "}
+              <chakra.span fontWeight={600} color="gray.800">
+                {isoforms[1].sequence?.code.length ?? 0}
+              </chakra.span>
+              , alignment:{" "}
+              <chakra.span fontWeight={600} color="gray.800">
+                {alignment[0].sequence.length ?? 0}
+              </chakra.span>
+            </Text>
+          </Box>
+        )}
+      </Flex>
+    </Flex>
+  );
+});

--- a/src/components/isoform/DropData.tsx
+++ b/src/components/isoform/DropData.tsx
@@ -1,0 +1,93 @@
+import { Box, Field, Skeleton, Text } from "@chakra-ui/react";
+import { observer } from "mobx-react";
+import { useDropzone } from "react-dropzone";
+import { useError } from "../../hooks/useError";
+import IsoformStore from "../../store/IsoformStore";
+
+// const acceptedFormats = ["fasta", "pdb", "net"] as const;
+const acceptedFormats = ["pdb"] as const;
+
+const dropzoneAccept = {
+  "text/plain": acceptedFormats.map((format) => `.${format}`),
+};
+
+// type Props = {
+//   onClose: () => void;
+// };
+
+export default observer(function LoadData({
+  isoform,
+}: {
+  isoform: IsoformStore;
+}) {
+  // const store = useContext(StoreContext);
+  const onError = useError();
+  //   const [state, dispatch] = useReducer(reducer, initialState, (state) => ({
+  //     ...state,
+  //     files: store.files,
+  //   }));
+  const onClose = () => {};
+
+  //   const { files } = state;
+
+  const onDrop = async (acceptedFiles: File[]) => {
+    // console.time("onDrop");
+    await isoform.pdb.loadFiles(acceptedFiles);
+
+    isoform.pdb.errors.forEach((error) => onError(error));
+    isoform.pdb.errors = [];
+
+    // console.timeEnd("onDrop");
+  };
+
+  const { open, getRootProps, getInputProps, isDragActive } = useDropzone({
+    // noClick: true,
+    accept: dropzoneAccept,
+    onDropRejected: (rejectedFiles) =>
+      rejectedFiles.forEach((rejectedFile) =>
+        onError({
+          title: `Cannot open ${rejectedFile.file.name}`,
+          description: rejectedFile.errors
+            .map(({ message }) => message)
+            .join("\n"),
+        })
+      ),
+    onDrop,
+  });
+
+  const { error } = isoform.pdb;
+  const isError = !!error;
+
+  return (
+    <Field.Root invalid={isError}>
+      <Skeleton
+        w="100%"
+        // h="360px"
+        loading={isoform.pdb.isLoading}
+        // rounded="md"
+        border="1px dashed #ccc"
+      >
+        <div style={{ width: "100%", height: "100%" }} {...getRootProps()}>
+          <input {...getInputProps()} />
+          <Box
+            p={3}
+            bg={isDragActive ? "gray.200" : "gray.50"}
+            w="100%"
+            h="100%"
+            color="gray.600"
+            fontSize="medium"
+          >
+            {isDragActive ? (
+              <Text>Drop the files here ...</Text>
+            ) : (
+              <Text>
+                Drag and drop <code>.pdb</code> files here, or click to select.
+              </Text>
+            )}
+          </Box>
+        </div>
+      </Skeleton>
+      {/* <Field.ErrorText maxW={430}>Error: {error}</Field.ErrorText> */}
+    </Field.Root>
+  );
+});

--- a/src/components/isoform/FileInput.tsx
+++ b/src/components/isoform/FileInput.tsx
@@ -1,0 +1,41 @@
+import { Box } from "@chakra-ui/react";
+import React, { useCallback } from "react";
+import { useDropzone } from "react-dropzone";
+
+export default function FileInput() {
+  const onDrop = useCallback((acceptedFiles: File[]) => {
+    acceptedFiles.forEach((file) => {});
+  }, []);
+  const { acceptedFiles, getRootProps, getInputProps, isDragActive } =
+    useDropzone({
+      accept: {
+        "text/plain": [".pdb"],
+      },
+      onDrop,
+    });
+
+  const files = acceptedFiles.map((file) => (
+    <li key={file.name}>
+      {file.name} - {file.size} bytes
+    </li>
+  ));
+
+  return (
+    <Box>
+      <Box {...getRootProps({ className: "dropzone" })} p={10}>
+        <input {...getInputProps()} />
+        {isDragActive ? (
+          <p>Drop the files here ...</p>
+        ) : (
+          <p>
+            Drag 'n' drop <code>.pdb</code> files here, or click to select files
+          </p>
+        )}
+      </Box>
+      <aside>
+        <h4>Files:</h4>
+        <ul>{files}</ul>
+      </aside>
+    </Box>
+  );
+}

--- a/src/components/isoform/Graph.tsx
+++ b/src/components/isoform/Graph.tsx
@@ -1,0 +1,64 @@
+import { Box, Text } from "@chakra-ui/react";
+import IsoformStore from "../../store/IsoformStore";
+import { useEffect, useRef } from "react";
+import ForceGraph, { type ForceGraphMethods } from "react-force-graph-3d";
+import { observer } from "mobx-react";
+
+export default observer(function GraphComponent({
+  isoform,
+}: {
+  isoform: IsoformStore;
+}) {
+  const ref = useRef<ForceGraphMethods | undefined>(undefined);
+  //   if (isoform.pdb.network.nodes.length === 0) {
+  //     return <Box w={500} h={500} />;
+  //   }
+
+  useEffect(() => {
+    /**
+     * How set initial zoom level?
+     *
+     * https://github.com/vasturiano/3d-force-graph/issues/20
+     *
+     * e.camera.position.z=150*Math.cbrt(e.forceGraph.graphData().nodes.length)
+     *
+     * myGraph.cameraPosition({ z: 1000 });
+     *
+     * myGraph.controls().maxDistance = 2000;
+     */
+    if (ref.current) {
+      const g = ref.current;
+      g.cameraPosition({ z: 200 });
+      // setTimeout(() => {
+      //   g.zoomToFit(400, 0);
+      // }, 100);
+    }
+  }, [ref]);
+
+  const { network } = isoform.pdb;
+
+  return (
+    <Box border="1px solid #eeeeee">
+      <ForceGraph
+        ref={ref}
+        height={350}
+        width={500}
+        nodeOpacity={0.9}
+        linkColor="#000000"
+        linkOpacity={0.7}
+        linkWidth={0.3}
+        graphData={network}
+        linkSource="sourceId"
+        linkTarget="targetId"
+        showNavInfo={false}
+        // nodeLabel="label"
+        nodeLabel={(node) =>
+          `<span style="color: #333333">${node.label}</span>`
+        }
+        nodeRelSize={1}
+        backgroundColor="#ffffff"
+        enableNodeDrag={false}
+      />
+    </Box>
+  );
+});

--- a/src/components/isoform/InputTextArea.tsx
+++ b/src/components/isoform/InputTextArea.tsx
@@ -1,0 +1,67 @@
+import {
+  Box,
+  Button,
+  Field,
+  Flex,
+  Spacer,
+  Textarea,
+  TextareaProps,
+} from "@chakra-ui/react";
+import { ChangeEvent, useState } from "react";
+
+interface Props extends TextareaProps {
+  isoID: number;
+  onLoadContent: (content: string) => void;
+  onChangeContent?: (content: string) => void;
+  value?: string;
+  error?: string;
+}
+export default function InputTextArea(props: Props) {
+  const [_content, setContent] = useState(props.value ?? "");
+  const { isoID, onLoadContent, onChangeContent, value, error, ...rest } =
+    props;
+
+  const content = value ?? _content;
+
+  const onChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
+    if (onChangeContent) {
+      onChangeContent(event.target.value);
+    } else {
+      setContent(event.target.value);
+    }
+  };
+
+  const onClickLoad = () => {
+    onLoadContent(content);
+    if (onChangeContent === undefined) {
+      setContent("");
+    }
+  };
+  const isError = !!error;
+
+  return (
+    <Box display="flex" flexDir="column">
+      <Field.Root invalid={isError}>
+        <Textarea
+          resize="none"
+          size="sm"
+          {...rest}
+          value={content}
+          onChange={onChange}
+        />
+        <Field.ErrorText>Error: {error}</Field.ErrorText>
+      </Field.Root>
+      <Flex mt={2}>
+        <Spacer />
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={content === ""}
+          onClick={onClickLoad}
+        >
+          Load
+        </Button>
+      </Flex>
+    </Box>
+  );
+}

--- a/src/components/isoform/IsoformAlluvialDiagram.tsx
+++ b/src/components/isoform/IsoformAlluvialDiagram.tsx
@@ -1,0 +1,53 @@
+import { Button, Flex, Text } from "@chakra-ui/react";
+import { observer } from "mobx-react";
+import { useContext } from "react";
+import { StoreContext } from "../../store";
+import Diagram from "../Diagram";
+import { saveSvg } from "../../io/save-svg";
+import { MdFileDownload } from "react-icons/md";
+
+export default observer(function IsoformAlluvialDiagram() {
+  const store = useContext(StoreContext);
+  const downloadSvg = () => {
+    store.setSelectedModule(null);
+    const svg = document.getElementById("alluvialSvg") as SVGSVGElement | null;
+    if (!svg) return;
+
+    const filename =
+      store.diagram.children.map((n) => n.name).join("-") + ".svg";
+
+    setTimeout(() => saveSvg(svg, filename), 500);
+  };
+
+  return (
+    <Flex direction="column" align="center">
+      <Text color="gray.600" mt={2} maxW="640px" textAlign="center">
+        Explore modular differences between the two isoforms in an alluvial
+        diagram.
+      </Text>
+
+      <Flex direction="row" alignItems="center" mt={4} gap={4}>
+        <Button
+          type="button"
+          disabled={!store.input.canGenerateAlluvial}
+          onClick={store.input.generateAlluvialDiagram}
+        >
+          {store.input.haveAlluvial ? "Re-generate Diagram" : "Generate Diagram"}
+        </Button>
+        {store.input.haveAlluvial && (
+          <Button
+            type="button"
+            onClick={downloadSvg}
+            aria-label="Download SVG"
+          >
+            <MdFileDownload aria-hidden="true" />
+            Download SVG
+          </Button>
+        )}
+      </Flex>
+
+      <Flex mt={8}></Flex>
+      <Diagram width={900} height={500} />
+    </Flex>
+  );
+});

--- a/src/components/isoform/IsoformApp.tsx
+++ b/src/components/isoform/IsoformApp.tsx
@@ -1,0 +1,111 @@
+import { Box, Container, Flex, Heading, Text } from "@chakra-ui/react";
+import { observer } from "mobx-react";
+import { useContext } from "react";
+import { StoreContext } from "../../store";
+import StepHeading from "./StepHeading";
+import AlignSequences from "./AlignSequences";
+import LoadData from "./LoadData";
+import PartitionNetworks from "./PartitionNetworks";
+import useEventListener from "../../hooks/useEventListener";
+import IsoformAlluvialDiagram from "./IsoformAlluvialDiagram";
+import SequenceView from "./SequenceView";
+import { LuCircleCheck } from "react-icons/lu";
+import DropData from "./DropData";
+import { Button } from "../Sidebar/components";
+
+export default observer(function IsoformApp() {
+  const store = useContext(StoreContext);
+  useEventListener("keydown", (event) => {
+    // @ts-ignore
+    const key = event?.key;
+    if (!store.editMode && key === "e") {
+      store.input.loadExample(store.input.exampleData[0]);
+    }
+  });
+
+  return (
+    <Container
+      mt="100px"
+      maxW={1800}
+      display="flex"
+      flexDir="column"
+      alignItems="center"
+    >
+      <Flex id="step1" direction="column" alignItems="center" mb={20}>
+        <StepHeading step={1} title="Load data" />
+
+        <Text color="gray.600" mt={2} maxW="640px" textAlign="center">
+          Drop your own <code>.pdb</code> files below, or pick an example to get
+          started.
+        </Text>
+
+        <Flex gap="24px" mt={6} wrap="wrap" justify="center">
+          {store.input.isoforms.map((isoformStore, i) => (
+            <Flex key={i} direction="column" maxW={{ base: 400, md: 600 }}>
+                <Heading as="h3" size="lg" mb={3} display="flex" fontWeight={600}>
+                  Isoform {i + 1}
+                  <Box
+                    as={LuCircleCheck}
+                    ml={3}
+                    alignSelf="center"
+                    color={
+                      isoformStore.pdb.numDatasets > 0
+                        ? "green.500"
+                        : "gray.200"
+                    }
+                  />
+                </Heading>
+
+                <DropData isoform={isoformStore} />
+
+                {isoformStore.sequence && (
+                  <Flex mt={6} direction="column">
+                    {/* <Heading as="h4" size="sm">
+                      Sequence
+                    </Heading> */}
+                    <SequenceView code={isoformStore.sequence.code} />
+                    <Button
+                      alignSelf="end"
+                      width="auto"
+                      onClick={isoformStore.pdb.clear}
+                    >
+                      Clear
+                    </Button>
+                  </Flex>
+                )}
+            </Flex>
+          ))}
+        </Flex>
+
+        <Flex mt={10} direction="column" alignItems="center">
+          <Heading as="h4" size="md" mb={4} fontWeight={600}>
+            Load example data
+          </Heading>
+          <LoadData />
+        </Flex>
+      </Flex>
+
+      <Flex id="step2" direction="column" alignItems="center" mb={20}>
+        <StepHeading step={2} title="Align sequences" />
+
+        <AlignSequences />
+
+        <Flex mt={8}></Flex>
+      </Flex>
+
+      <Flex id="step3" direction="column" alignItems="center" mb={20}>
+        <StepHeading step={3} title="Generate and partition networks" />
+
+        <PartitionNetworks />
+
+        <Flex mt={8}></Flex>
+      </Flex>
+
+      <Flex id="step4" direction="column" alignItems="center" mb={20}>
+        <StepHeading step={4} title="Compare structures" />
+
+        <IsoformAlluvialDiagram />
+      </Flex>
+    </Container>
+  );
+});

--- a/src/components/isoform/LoadData.tsx
+++ b/src/components/isoform/LoadData.tsx
@@ -1,0 +1,85 @@
+import { Box, Input, InputGroup, Table } from "@chakra-ui/react";
+import { observer } from "mobx-react";
+import { useContext } from "react";
+import { StoreContext } from "../../store";
+
+export default observer(function LoadData() {
+  const store = useContext(StoreContext);
+
+  const columns = [
+    "GeneID",
+    "Isoform1",
+    "Isoform2",
+    "Mechanism",
+    "Time1",
+    "Time2",
+    "Description",
+  ];
+
+  return (
+    <Box>
+      <InputGroup
+        endElement={
+          <Box
+            color="gray.500"
+            whiteSpace="nowrap"
+            fontVariantNumeric="tabular-nums"
+            fontSize="sm"
+          >
+            {`${store.input.filteredExampleData.length} / ${store.input.exampleData.length}`}
+          </Box>
+        }
+        endElementProps={{ width: 100 }}
+      >
+        <Input
+          placeholder="Search…"
+          aria-label="Search example data"
+          autoComplete="off"
+          spellCheck={false}
+          value={store.input.filterText}
+          onChange={(event) => store.input.setFilterText(event.target.value)}
+        />
+      </InputGroup>
+      <Box maxH={210} overflowY="auto">
+        <Table.Root variant="line" size="sm">
+          <Table.Header>
+            <Table.Row>
+              {columns.map((column) => (
+                <Table.ColumnHeader key={column}>{column}</Table.ColumnHeader>
+              ))}
+            </Table.Row>
+          </Table.Header>
+          <Table.Body>
+            {store.input.filteredExampleData.map((row) => (
+              <Table.Row
+                key={row.id}
+                cursor="pointer"
+                transition="background-color 0.15s ease"
+                _hover={{ bg: "gray.100" }}
+                onClick={() => store.input.loadExample(row)}
+              >
+                <Table.Cell>{row.geneID}</Table.Cell>
+                <Table.Cell>
+                  *{row.isoform1.substring(row.geneID.length)}
+                </Table.Cell>
+                <Table.Cell>
+                  *{row.isoform2.substring(row.geneID.length)}
+                </Table.Cell>
+                <Table.Cell>{row.mechanism}</Table.Cell>
+                <Table.Cell>{row.time1}</Table.Cell>
+                <Table.Cell>{row.time2}</Table.Cell>
+                <Table.Cell
+                  maxW={{ base: 100, lg: 400 }}
+                  overflowX="auto"
+                  title={row.description}
+                >
+                  {row.description}
+                </Table.Cell>
+              </Table.Row>
+            ))}
+          </Table.Body>
+        </Table.Root>
+      </Box>
+    </Box>
+  );
+});

--- a/src/components/isoform/NetworkInfo.tsx
+++ b/src/components/isoform/NetworkInfo.tsx
@@ -1,0 +1,58 @@
+import { Box, Button, Text } from "@chakra-ui/react";
+import { motion } from "framer-motion";
+import IsoformStore from "../../store/IsoformStore";
+import { observer } from "mobx-react";
+import FileSaver from "file-saver";
+import { MdFileDownload } from "react-icons/md";
+
+export const ExportNetwork = observer(function _ExportNetwork({
+  isoform,
+}: {
+  isoform: IsoformStore;
+}) {
+  const { netFile: file, network } = isoform.pdb;
+
+  return <Box></Box>;
+});
+
+export default observer(function NetworkInfo({
+  isoform,
+}: {
+  isoform: IsoformStore;
+}) {
+  const store = isoform.pdb;
+  const { netFile: file, network, name } = store;
+
+  const filename = `${name}.net`;
+
+  const saveNetwork = () => {
+    const blob = new Blob([isoform.pdb.serializeNetwork()], {
+      type: "plain/text;charset=utf-8",
+    });
+    FileSaver.saveAs(blob, filename);
+  };
+
+  return (
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+    >
+      <Box display="flex" alignItems="center" justifyContent="space-between">
+        <Text>
+          {`${network.nodes.length.toLocaleString()} nodes and ${network.links.length.toLocaleString()} links.`}
+        </Text>
+        <Button
+          type="button"
+          ml={2}
+          size="xs"
+          onClick={saveNetwork}
+          disabled={network.links.length === 0}
+        >
+          Export network
+          <MdFileDownload size={16} aria-hidden="true" />
+        </Button>
+      </Box>
+    </motion.div>
+  );
+});

--- a/src/components/isoform/PartitionNetworks.tsx
+++ b/src/components/isoform/PartitionNetworks.tsx
@@ -1,0 +1,239 @@
+import {
+  Alert,
+  Box,
+  Button,
+  chakra,
+  Checkbox,
+  Flex,
+  Heading,
+  HStack,
+  NumberInput,
+  Slider,
+  Text,
+} from "@chakra-ui/react";
+import { useContext } from "react";
+import { observer } from "mobx-react";
+import { StoreContext } from "../../store";
+import { motion } from "framer-motion";
+import { TruncatedFilename } from "../LoadNetworks/Item/components";
+import humanFileSize from "../../utils/human-file-size";
+import IsoformStore from "../../store/IsoformStore";
+import Graph from "./Graph";
+import { PdbProgress } from "./Progress";
+import NetworkInfo from "./NetworkInfo";
+import SelectButtonGroup from "../General/SelectButtonGroup";
+import pluralize from "../../utils/pluralize";
+
+const InfomapItem = observer(
+  ({ isoform, pdb }: { isoform: IsoformStore; pdb?: boolean }) => {
+    const id = `${isoform.isoID}`;
+
+    const store = pdb ? isoform.pdb : isoform;
+    const { netFile: file } = store;
+
+    const disabled = store.infomap.isRunning;
+    const numTrials = store.infomapArgs.numTrials ?? 10;
+    const setNumTrials = (numTrials: number) => store.setArgs({ numTrials });
+    const twoLevel = store.infomapArgs.twoLevel ?? false;
+    const setTwoLevel = (value: boolean) => store.setArgs({ twoLevel: value });
+    const run = () => store.runInfomap();
+
+    return (
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+      >
+        <Box
+          opacity={disabled ? 0.6 : 1}
+          pointerEvents={disabled ? "none" : "auto"}
+        >
+          <HStack justify="space-between">
+            <label htmlFor={id} style={{ fontSize: "0.875rem", paddingTop: 4 }}>
+              Trials
+            </label>
+            <NumberInput.Root
+              id={id}
+              size="xs"
+              value={String(numTrials)}
+              onValueChange={(details) =>
+                setNumTrials(Math.max(1, +details.value))
+              }
+              min={1}
+              max={100}
+              step={1}
+            >
+              <NumberInput.Input />
+              <NumberInput.Control>
+                <NumberInput.IncrementTrigger />
+                <NumberInput.DecrementTrigger />
+              </NumberInput.Control>
+            </NumberInput.Root>
+          </HStack>
+          <Checkbox.Root
+            disabled={disabled}
+            size="sm"
+            checked={twoLevel}
+            onCheckedChange={(details) => setTwoLevel(details.checked === true)}
+          >
+            <Checkbox.HiddenInput />
+            <Checkbox.Control />
+            <Checkbox.Label>Two-level</Checkbox.Label>
+          </Checkbox.Root>
+          <Button
+            mt={1}
+            disabled={disabled}
+            loading={disabled}
+            size="xs"
+            width="full"
+            type="submit"
+            onClick={run}
+          >
+            {isoform.haveModules ? "Re-run Infomap" : "Run Infomap"}
+          </Button>
+        </Box>
+        {file && (
+          <Box>
+            <Text>{humanFileSize(file.size)}</Text>
+            {file.isMultilayer && (
+              <Text>
+                {!file.isExpanded
+                  ? pluralize(file.numLayers!, "layer")
+                  : "layer " + file.layerId}
+              </Text>
+            )}
+            {file.numTopModules && (
+              <Text>{pluralize(file.numTopModules, "top module")}</Text>
+            )}
+            {file.cluLevel && <Text>level {file.cluLevel}</Text>}
+            {!file.cluLevel && file.numLevels && (
+              <Text>{pluralize(file.numLevels, "level")}</Text>
+            )}
+            {file.codelength && (
+              <Text>{file.codelength.toFixed(3) + " bits"}</Text>
+            )}
+          </Box>
+        )}
+      </motion.div>
+    );
+  },
+);
+
+const NetworkItem = observer(({ isoform }: { isoform: IsoformStore }) => {
+  const { pdb } = isoform;
+  const file = pdb.netFile;
+
+  return (
+    <Box maxW="100%" h="100%" pos="relative" bg="transparent">
+      <Heading size="md" mb={2} fontWeight={600}>
+        Isoform {isoform.isoID}
+      </Heading>
+      <Box>
+        <Graph isoform={isoform} />
+        {pdb.numDatasets > 1 && (
+          <Box>
+            <SelectButtonGroup
+              value={pdb.selectedIndex}
+              onChangeSelected={(value) =>
+                pdb.setSelectedIndex(value as number)
+              }
+            >
+              {Array.from(Array(pdb.numDatasets).keys()).map((i) => (
+                <Button key={i} value={i}>
+                  {i + 1}
+                </Button>
+              ))}
+            </SelectButtonGroup>
+          </Box>
+        )}
+      </Box>
+      <Box>
+        <Box
+          bg="gray.50"
+          fontSize="sm"
+          borderRadius={5}
+          boxShadow="md"
+          p={2}
+          mt={8}
+          pos="relative"
+        >
+          <TruncatedFilename
+            name={file?.filename ?? "Pending..."}
+            maxLength={100}
+          />
+
+          <NetworkInfo isoform={isoform} />
+
+          <InfomapItem isoform={isoform} pdb />
+        </Box>
+
+        <PdbProgress isoform={isoform} />
+      </Box>
+    </Box>
+  );
+});
+
+export default observer(function PartitionNetworks() {
+  const store = useContext(StoreContext);
+
+  const { input } = store;
+
+  return (
+    <Flex direction="column" alignItems="center" mb={1}>
+      <Text color="gray.600" maxW="640px" mt={2} textAlign="center">
+        For each isoform, build a network linking amino acids that sit close in
+        3D space. Nodes are identified by their aligned position so equivalent
+        residues share an identity across both networks.
+      </Text>
+
+      <Box mt={6} w="400px">
+        <Box
+          fontSize="sm"
+          color="gray.700"
+          mb={2}
+          style={{ fontVariantNumeric: "tabular-nums" }}
+        >
+          Link distance threshold:{" "}
+          <chakra.span fontWeight={600}>
+            {store.input.linkDistanceThreshold.toFixed(1)}&nbsp;Å
+          </chakra.span>
+        </Box>
+        <Slider.Root
+          aria-label={["Link distance threshold"]}
+          colorPalette="blue"
+          value={[store.input.linkDistanceThreshold]}
+          onValueChange={(details) =>
+            store.input.setLinkDistanceThreshold(details.value[0])
+          }
+          step={0.1}
+          min={0.1}
+          max={50}
+        >
+          <Slider.Control>
+            <Slider.Track bg="gray.200">
+              <Slider.Range bg="blue.500" />
+            </Slider.Track>
+            <Slider.Thumb index={0}>
+              <Slider.HiddenInput />
+            </Slider.Thumb>
+          </Slider.Control>
+        </Slider.Root>
+      </Box>
+
+      <Flex mt={10} gap="24px" justify="center" wrap="wrap">
+        <NetworkItem isoform={store.input.isoformStore1} />
+        <NetworkItem isoform={store.input.isoformStore2} />
+      </Flex>
+
+      {input.canGenerateAlignment && !input.haveAlignment && (
+        <Alert.Root mt={10} maxW={400} status="warning">
+          <Alert.Indicator />
+          <Alert.Content>
+            Align the sequences before partitioning them to make the structures
+            comparable.
+          </Alert.Content>
+        </Alert.Root>
+      )}
+    </Flex>
+  );
+});

--- a/src/components/isoform/Progress.tsx
+++ b/src/components/isoform/Progress.tsx
@@ -1,0 +1,45 @@
+import { Progress } from "@chakra-ui/react";
+import { observer } from "mobx-react";
+import IsoformStore from "../../store/IsoformStore";
+
+function ProgressComponent({ value }: { value: number }) {
+  return (
+    <Progress.Root
+      value={value}
+      max={100}
+      size="sm"
+      mt={2}
+      colorPalette="blue"
+      striped
+      animated
+    >
+      <Progress.Track bg="gray.200" borderRadius="full">
+        {/* The default Range has a 0.3s width transition. Infomap fires
+            progress events faster than the animation completes, so the
+            transition was clipping each update — the bar appeared to stall.
+            Drop the transition so the fill tracks the value directly. */}
+        <Progress.Range bg="blue.500" transition="none" />
+      </Progress.Track>
+    </Progress.Root>
+  );
+}
+
+export const IsoformProgress = observer(
+  ({ isoform }: { isoform: IsoformStore }) => {
+    const { infomap } = isoform;
+    if (!infomap.isRunning) {
+      return null;
+    }
+    return <ProgressComponent value={infomap.progress} />;
+  }
+);
+
+export const PdbProgress = observer(
+  ({ isoform }: { isoform: IsoformStore }) => {
+    const { infomap } = isoform.pdb;
+    if (!infomap.isRunning) {
+      return null;
+    }
+    return <ProgressComponent value={infomap.progress} />;
+  }
+);

--- a/src/components/isoform/SequenceView.tsx
+++ b/src/components/isoform/SequenceView.tsx
@@ -1,0 +1,26 @@
+import { Code } from "@chakra-ui/react";
+import { getAAColor } from "../../store/PdbStore";
+
+type SequenceViewProps = {
+  code: string;
+};
+
+export default function SequenceView({ code }: SequenceViewProps) {
+  return (
+    <Code
+      display="block"
+      whiteSpace="normal"
+      wordBreak="break-all"
+      overflowWrap="anywhere"
+      px={2}
+      py={1}
+      lineHeight="1.6"
+    >
+      {[...code].map((c, i) => (
+        <span key={`code[${i}]`} style={{ backgroundColor: getAAColor(c) }}>
+          {c}
+        </span>
+      ))}
+    </Code>
+  );
+}

--- a/src/components/isoform/StepHeading.tsx
+++ b/src/components/isoform/StepHeading.tsx
@@ -1,0 +1,35 @@
+import { Box, Circle, Flex, Heading } from "@chakra-ui/react";
+
+export default function StepHeading({
+  step,
+  title,
+  active,
+}: {
+  step: number;
+  title: string;
+  active?: boolean;
+}) {
+  const accentColor = "var(--chakra-colors-blue-600)";
+
+  return (
+    <Flex className="step-heading" alignItems="center" mb={1}>
+      <Circle
+        size="40px"
+        border={active ? `2px solid ${accentColor}` : "0"}
+        bgColor="#eeeeee"
+        fontWeight="bold"
+        mr={4}
+      >
+        {step}
+      </Circle>
+      <Heading
+        size="2xl"
+        fontWeight={600}
+        letterSpacing="-0.01em"
+        style={{ textWrap: "balance" }}
+      >
+        {title}
+      </Heading>
+    </Flex>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,5 @@
 body {
     margin: 0;
-    overflow: hidden;
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
     "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
     sans-serif;

--- a/src/store/InputStore.ts
+++ b/src/store/InputStore.ts
@@ -1,0 +1,341 @@
+import { action, computed, makeObservable, observable } from "mobx";
+import type { Store as RootStore } from "./Store"
+import { parseAcceptedFiles, setIdentifiers } from "../components/LoadNetworks/utils";
+import { NetworkFile } from "../components/LoadNetworks";
+import { parse, parseTree } from "@mapequation/infomap-parser";
+import Infomap from "@mapequation/infomap";
+import IsoformStore from "./IsoformStore";
+import { isFasta, parseFasta } from "../utils/sequence-parser";
+import BioMSA from "biomsa";
+import { tsv } from "d3";
+import { aaCharToName } from "./PdbStore";
+
+type AcceptedFormats = "fasta" | "pdb" | "net";
+
+
+export type ErrorItem = { title: string, description: string }
+
+export const getExtension = (file: File) => {
+    return file.name.split(".").pop()!;
+}
+
+
+const exampleItem = {
+    id: 0,
+    Aliases: "ATKEA1,KEA1",
+    Description: "Encodes a member of the cation/proton antiporters-2 antiporter superfamily, the K efflux antiporter KEA1 that is localized to the chloroplast envelope.",
+    GeneID: "AT1G01790",
+    Isoform1: "AT1G01790_P1",
+    Isoform2: "AT1G01790_c3",
+    Mechanism: "A3",
+    Time1: "WT_3h",
+    Time2: "WT_0h",
+} as const;
+
+type ExampleItemKeys = keyof typeof exampleItem;
+type ExampleItemKeysNoID = Omit<ExampleItemKeys, "id">;
+// type ExampleItemType = typeof exampleItem[ExampleItemKeys];
+// type ExampleItem = {
+//     // id: number;
+//     [key in ExampleItemKeys]: string;
+// };
+type ExampleItem = {
+    id: number,
+    aliases: string
+    description: string
+    geneID: string
+    isoform1: string
+    isoform2: string
+    mechanism: string
+    time1: string
+    time2: string
+};
+
+export default class InputStore {
+    rootStore: RootStore;
+    acceptedFormats = ["fasta", "pdb", "net"];
+
+    inputFiles: { format: AcceptedFormats, file: File }[] = [];
+
+    isoformStore1: IsoformStore;
+    isoformStore2: IsoformStore;
+
+    // networks: NetworkFile[] = [];
+    linkDistanceThreshold = 7;
+
+    isLoadingFiles = false;
+    errors: ErrorItem[] = [];
+
+    exampleData: ExampleItem[] = [];
+
+    filterText: string = "";
+
+    haveAlluvial = false;
+
+    infomap = {
+        progress: 0,
+        isRunning: false,
+        error: "",
+    }
+    // infomapProgress: number = 0;
+
+    constructor(rootStore: RootStore) {
+        this.rootStore = rootStore;
+        makeObservable(this, {
+            haveAlluvial: observable,
+            exampleData: observable.ref,
+            inputFiles: observable.ref,
+            linkDistanceThreshold: observable,
+            isLoadingFiles: observable,
+            filterText: observable,
+            filteredExampleData: computed,
+            canGenerateAlluvial: computed,
+            networks: computed,
+            alignment: computed,
+            canGenerateAlignment: computed,
+            haveAlignment: computed,
+            infomap: observable,
+        })
+        this.isoformStore1 = new IsoformStore(this, 1);
+        this.isoformStore2 = new IsoformStore(this, 2);
+
+        this.rootStore.setSortModulesBy("nodeId");
+        this.rootStore.setHeight(500);
+
+        this.loadExampleTable();
+    }
+
+    get isoforms() {
+        return [this.isoformStore1, this.isoformStore2];
+    }
+
+    get alignment() {
+        return this.isoforms.map(isoform => ({ name: isoform.name, sequence: isoform.alignedSequence }));
+    }
+
+    get canGenerateAlignment() {
+        return this.isoforms.map(isoform => isoform.sequence?.code && !isoform.alignedSequence).filter(v => v).length === 2;
+    }
+
+    get networks() {
+        // return this.isoforms.map(isoform => isoform.netFile);
+        return this.isoforms.map(isoform => isoform.pdb.netFile);
+    }
+
+    get filteredExampleData() {
+        const re = new RegExp(this.filterText, "i");
+        return this.exampleData.filter((row => {
+            return re.test(row.description) || re.test(row.geneID) || re.test(row.isoform1) || re.test(row.isoform2);
+        }));
+    }
+
+    get canGenerateAlluvial() {
+        return this.isoformStore1.haveModules && this.isoformStore2.haveModules;
+    }
+
+    getFiles(extension: AcceptedFormats) {
+        return this.inputFiles.filter(item => item.format === extension).map(item => item.file);
+    }
+
+    setLinkDistanceThreshold = action((value: number) => {
+        this.linkDistanceThreshold = value;
+        this.isoforms.forEach(isoform => isoform.pdb.setLinkDistanceThreshold(value));
+    })
+
+    setFilterText = action((value: string) => {
+        this.filterText = value;
+    })
+
+    loadFiles = action(async (files: File[]) => {
+        console.time("InputStore.loadFiles")
+        this.isLoadingFiles = true;
+
+        files.forEach(file => {
+            const ext = getExtension(file);
+            if (!this.acceptedFormats.includes(ext)) {
+                this.errors.push({ title: `Unrecognised extension: '${ext}'`, description: `File '${file.name}' ignored.` })
+                return;
+            }
+            this.inputFiles.push({ format: ext as AcceptedFormats, file });
+        })
+
+        this.inputFiles = [...this.inputFiles];
+
+        await this.parseFiles();
+
+        this.isLoadingFiles = false;
+        console.timeEnd("InputStore.loadFiles")
+    })
+
+    parseFiles = action(async () => {
+        const netFiles = this.getFiles("net");
+        if (netFiles.length > 0) {
+            if (netFiles.length !== 2) {
+                this.errors.push({ title: "Wrong number of network files", description: `Got ${netFiles.length}, should be 2.` });
+            } else {
+                const [networks, errors] = await parseAcceptedFiles(
+                    netFiles,
+                    [],
+                    this.acceptedFormats,
+                    "name"
+                );
+                errors.forEach(error => {
+                    this.errors.push({ title: `Error loading '${error.file}`, description: error.errors.map(e => e.message).join('\n') })
+                })
+
+                await Promise.all([
+                    this.isoformStore1.setNetworkFile(networks[0]),
+                    this.isoformStore2.setNetworkFile(networks[1]),
+                ])
+                this.generateAlluvialDiagram();
+                console.log("First node:", networks[0].nodes[0])
+            }
+        }
+    })
+
+    loadExampleTable = action(async () => {
+        console.log(`Load exmaple table...`);
+        // load a tsv file with d3
+        const data = await tsv(encodeURI(`/isoformmapper/data/example_data.tsv`), (row: any, index: number) => {
+            return {
+                id: index,
+                aliases: row.Aliases,
+                description: row.Description,
+                geneID: row.GeneID,
+                isoform1: row.Isoform1,
+                isoform2: row.Isoform2,
+                mechanism: row.Mechanism,
+                time1: row.Time1,
+                time2: row.Time2,
+            }
+        }) as ExampleItem[];
+        console.log("Got data:", data);
+        this.exampleData = data;
+    })
+
+    loadExample = action(async (item: ExampleItem) => {
+
+        console.log("Load example:", item);
+
+        await Promise.all([
+            this.isoformStore1.loadExample(item.isoform1),
+            this.isoformStore2.loadExample(item.isoform2),
+        ])
+        console.log("Generate alignment...");
+        await this.generateAlignment();
+
+        console.log("Run Infomap...");
+        await this.runInfomap();
+
+        console.log("Generate alluvial diagram...");
+        this.generateAlluvialDiagram();
+    })
+
+    loadSequences = action(async (file: File) => {
+        console.log(`Load alignment from file '${file.name}'...`);
+
+        const content = await file.text();
+        const lines = content.split("\n");
+        if (!isFasta(lines)) {
+            throw new Error(`Could not parse '${file.name}' as a fasta file.`);
+        }
+        const sequences = parseFasta(lines);
+        console.log("Parsed sequences:", sequences);
+
+        const isoformsByName = new Map(this.isoforms.map(isoform => [isoform.name, isoform]));
+        for (let seq of sequences) {
+            const isoform = isoformsByName.get(seq.taxon);
+            if (isoform === undefined) {
+                this.errors.push({ title: `Sequence id '${seq.taxon}' not recognized among loaded isoforms.`, description: `Sequence id should match one of '${Array.from(isoformsByName.keys()).join(', ')}'.` })
+            } else {
+                isoform.setSequence(seq);
+            }
+        }
+
+        await this.generateAlignment();
+    })
+
+    generateAlignment = action(async () => {
+        console.log("Calculate alignment...")
+        //TODO: Check and handle missing sequence
+        const sequences = this.isoforms.map(iso => iso.sequence!.code)
+        const alignment = await BioMSA.align(sequences);
+        for (let i = 0; i < this.isoforms.length; ++i) {
+            this.isoforms[i].setAlignedSequence(alignment[i])
+        }
+
+        this.generateAlignedNetworks();
+    })
+
+    generateAlignedNetworks = action(() => {
+        console.log("Generate aligned networks...");
+        const { alignment } = this;
+        const N = alignment[0].sequence.length;
+        if (N === 0) {
+            return;
+        }
+        const sequences = alignment.map(item => item.sequence);
+        const [s1, s2] = sequences;
+        const s1Map: Map<number, string> = new Map();
+        const s2Map: Map<number, string> = new Map();
+        let pos1 = 1;
+        let pos2 = 1;
+        const getSiteName = (site: string) => {
+            if (site === '-') return '-';
+            return aaCharToName.get(site)!
+        }
+        for (let i = 0; i < N; ++i) {
+            const c1 = getSiteName(s1.charAt(i));
+            const c2 = getSiteName(s2.charAt(i));
+            const site = i + 1;
+            if (c1 === c2) {
+                // Use suffix '_C' when the node is common in both networks
+                s1Map.set(pos1, `${site}_${c1}_C`);
+                s2Map.set(pos2, `${site}_${c2}_C`);
+                ++pos1;
+                ++pos2;
+            }
+            else {
+                // Use suffix '_S' when the node only exists in a single network
+                s1Map.set(pos1, `${site}_${c1}_S`);
+                s2Map.set(pos2, `${site}_${c2}_S`);
+
+                if (c1 !== '-') {
+                    ++pos1;
+                }
+                if (c2 !== '-') {
+                    ++pos2;
+                }
+            }
+        }
+        this.isoformStore1.setAlignmentMap(s1Map);
+        this.isoformStore2.setAlignmentMap(s2Map);
+    })
+
+    get haveAlignment() {
+        return this.isoforms.every(isoform => isoform.haveAlignment);
+    }
+
+    generateAlluvialDiagram = action(async () => {
+        if (!this.canGenerateAlluvial) {
+            return;
+        }
+        console.log("Generate alluvial with network:", this.networks)
+        this.rootStore.setNetworks(this.networks);
+        this.haveAlluvial = true;
+    })
+
+    runInfomap = action(async () => {
+        await Promise.all([
+            this.isoformStore1.pdb.runInfomap(),
+            this.isoformStore2.pdb.runInfomap(),
+        ])
+    })
+
+    clear = action(() => {
+        this.haveAlluvial = false;
+        this.isoforms.forEach(isoform => {
+            isoform.clear();
+        })
+    })
+}

--- a/src/store/IsoformStore.ts
+++ b/src/store/IsoformStore.ts
@@ -1,0 +1,421 @@
+import { action, computed, makeObservable, observable, runInAction } from "mobx";
+import type InputStore from "./InputStore"
+import { parseAcceptedFiles, setIdentifiers } from "../components/LoadNetworks/utils";
+import { NetworkFile } from "../components/LoadNetworks";
+import { parse, parseTree } from "@mapequation/infomap-parser";
+import Infomap from "@mapequation/infomap";
+import { Arguments } from "@mapequation/infomap/arguments";
+import { calcStatistics } from "../components/LoadNetworks/utils"
+import PdbStore from "./PdbStore";
+import { ErrorItem } from "./InputStore";
+import { runInfomap } from "../utils/infomap";
+import { Sequence, isFasta, parseFasta } from "../utils/sequence-parser";
+
+const aaMap = new Map([
+    ["ALA", "A"], ["ARG", "R"], ["ASN", "N"], ["ASP", "D"], ["CYS", "C"], ["GLN", "Q"], ["GLU", "E"], ["GLY", "G"], ["HIS", "H"],
+    ["ILE", "I"], ["LEU", "L"], ["LYS", "K"], ["MET", "M"], ["PHE", "F"], ["PRO", "P"], ["SER", "S"], ["THR", "T"], ["TRP", "W"],
+    ["TYR", "Y"], ["VAL", "V"],
+    ["ASX", "B"],
+    ["GLX", "Z"]
+]);
+
+type AcceptedFormats = "fasta" | "pdb" | "net";
+
+export const getExtension = (file: File) => {
+    return file.name.split(".").pop()!;
+}
+
+type ExampleIsoformItem = {
+    id: string;
+    net: string;
+    pdb: string[];
+}
+type ExampleItem = {
+    id: string;
+    isoform1: ExampleIsoformItem;
+    isoform2: ExampleIsoformItem;
+    alignment: string;
+}
+
+type Coord = [number, number, number];
+
+type PdbItem = {
+    pos: number;
+    aa: string;
+    coords: [Coord, ...Coord[]]; // Minimum one coordinate
+}
+
+export type IsoformNode = {
+    id: string;
+    label: string;
+    path: string;
+}
+
+export type IsoformLink = {
+    source: string;
+    target: string;
+    id: string;
+}
+
+export type IsoformNetwork = {
+    nodes: IsoformNode[];
+    links: IsoformLink[];
+}
+
+type FilesByExt = {
+    "fasta": File[],
+    "pdb": File[],
+    "net": File[],
+}
+
+export default class IsoformStore {
+    inputStore: InputStore;
+    pdb: PdbStore;
+    isoID: number;
+    _name: string;
+
+    isLoading = false;
+    netFile: NetworkFile | null = null;
+
+    filesByExt: FilesByExt = {
+        "fasta": [],
+        "pdb": [],
+        "net": [],
+    };
+
+    network: IsoformNetwork = {
+        nodes: [],
+        links: [],
+    }
+
+    errors: { title: string, description: string }[] = [];
+
+    infomap = {
+        progress: 0,
+        isRunning: false,
+        error: "",
+        finished: false,
+    }
+
+    infomapArgs: Arguments = {
+        numTrials: 20,
+        output: "tree",
+    }
+
+    constructor(inputStore: InputStore, isoformID: number) {
+        this.inputStore = inputStore;
+        this.pdb = new PdbStore(this);
+        this.isoID = isoformID;
+        this._name = `${isoformID}`;
+        makeObservable(this, {
+            _name: observable,
+            name: computed,
+            isLoading: observable,
+            netFile: observable.ref,
+            infomap: observable,
+            infomapArgs: observable,
+            haveModules: computed,
+            network: observable.ref,
+            fastaContent: observable,
+            fastaError: observable,
+            pdbContent: observable,
+            sequence: observable.ref,
+            haveSequence: computed,
+            alignedSequence: observable,
+            alignmentMap: observable.ref,
+            haveAlignment: computed,
+        })
+    }
+
+    fastaContent: string = "";
+    setFastaContent = action((content: string) => {
+        this.fastaContent = content;
+    })
+
+    fastaError: string = "";
+
+    pdbContent: string = "";
+    setPdbContent = action((content: string) => {
+        this.pdbContent = content;
+    })
+
+    sequence: Sequence | null = null;
+    setSequence = action((seq: Sequence) => {
+        this.sequence = seq;
+    })
+
+    get haveSequence() {
+        return this.sequence !== null;
+    }
+
+    alignedSequence: string = "";
+    setAlignedSequence = action((code: string) => {
+        this.alignedSequence = code;
+    })
+
+    alignmentMap: Map<number, string> | null = null;
+    setAlignmentMap = action((alignmentMap: Map<number, string>) => {
+        this.alignmentMap = alignmentMap;
+        this.pdb.generateNetwork();
+    })
+
+    get haveAlignment() {
+        return this.alignmentMap !== null;
+    }
+
+
+    clear = action(() => {
+        this.isLoading = false;
+        this.netFile = null;
+        this.errors = [];
+
+        this.filesByExt = {
+            "fasta": [],
+            "pdb": [],
+            "net": [],
+        };
+
+        this.clearNetwork();
+        this.clearInfomap();
+        this.pdb.clear();
+    })
+
+    clearNetwork = action(() => {
+        this.network = {
+            nodes: [],
+            links: []
+        }
+    })
+
+    clearInfomap = action(() => {
+        this.infomap = {
+            progress: 0,
+            isRunning: false,
+            error: "",
+            finished: false,
+        }
+    })
+
+    get name() {
+        return this._name;
+    }
+    setName = action((name: string) => {
+        this._name = name;
+    })
+
+    get haveModules() {
+        return this.pdb.infomap.finished;
+    }
+
+    getFiles(extension: AcceptedFormats) {
+        return this.filesByExt[extension];
+    }
+
+    addError = action((error: ErrorItem) => {
+        this.errors.push(error);
+    })
+
+    loadExample = action(async (name: string) => {
+        this.setName(name);
+        console.log(`Load example '${name}'...`, this.alignedSequence)
+
+        const toFile = async (url: string) => {
+            const resp = await fetch(encodeURI(url));
+            const text = await resp.text();
+            const file = new File([text], url, { type: "text/plain" });
+            return file;
+        }
+
+        // const seqUrl = `/isoformmapper/data/FASTA/${name}.fasta`;
+        const pdbUrls = Array.from(Array(5).keys()).map(n => `/isoformmapper/data/Alphafold_PDBs/${name}/relaxed_model_${n + 1}_pred_0.pdb`);
+        // const urls = [seqUrl, ...pdbUrls];
+        const urls = pdbUrls;
+        const files = await Promise.all(urls.map(toFile))
+        await this.loadFiles(files);
+
+        console.log(`Load example '${name}' done!`, this.alignedSequence)
+    })
+
+    loadFiles = action(async (files: File[]) => {
+        // console.time("IsoformStore.loadFiles")
+        this.clear();
+        this.isLoading = true;
+
+
+        files.forEach(file => {
+            const ext = getExtension(file);
+            if (!Object.keys(this.filesByExt).includes(ext)) {
+                this.errors.push({ title: `Unrecognised extension: '${ext}'`, description: `File '${file.name}' ignored.` })
+                return;
+            }
+            this.filesByExt[ext as AcceptedFormats].push(file);
+        })
+
+        await this.parseFiles();
+
+        this.isLoading = false;
+        // console.timeEnd("IsoformStore.loadFiles")
+    })
+
+    parseFiles = action(async () => {
+
+        const netFiles = this.getFiles("net");
+        if (netFiles.length > 0) {
+            if (netFiles.length !== 1) {
+                this.errors.push({ title: `Isoform ${this.isoID} got too many network files`, description: `Got ${netFiles.length}, should be 1.` });
+            } else {
+                const [networks, errors] = await parseAcceptedFiles(
+                    netFiles,
+                    [],
+                    ["net"],
+                    "name"
+                );
+                errors.forEach(error => {
+                    this.errors.push({ title: `Error loading '${error.file}`, description: error.errors.map(e => e.message).join('\n') })
+                })
+
+                this.setNetworkFile(networks[0]);
+            }
+        }
+
+        const fastaFiles = this.getFiles("fasta");
+        if (fastaFiles.length > 0) {
+            await this.parseFastaFile(fastaFiles[0]);
+        }
+
+
+        const pdbFiles = this.getFiles("pdb");
+        await this.pdb.parsePdbFiles(pdbFiles);
+    })
+
+    parseFastaFile = action(async (file: File) => {
+        const content = await file.text();
+        await this.parseFastaContent(content, file.name);
+    })
+
+    loadFastaContent = action(async (content: string) => {
+        try {
+            await this.parseFastaContent(content);
+            this.fastaError = "";
+            this.setFastaContent("");
+        } catch (e: any) {
+            this.fastaError = e.message;
+            // this.addError({
+            //     title: "Sequence loading error",
+            //     description: e.message,
+            // });
+        }
+    })
+
+    parseFastaContent = action(async (content: string, filename?: string) => {
+        if (filename === undefined) {
+            filename = "loaded content"
+        }
+        const lines = content.split("\n");
+        if (!isFasta(lines)) {
+            throw new Error(`Could not parse ${filename} as a fasta file.`);
+        }
+        const sequences = parseFasta(lines);
+        if (sequences.length !== 1) {
+            throw new Error(`Found ${sequences.length} sequences in ${filename}, expected 1.`);
+        }
+        const seq = sequences[0];
+        const meta = seq.taxon.split(" | ");
+        if (meta.length > 1) {
+            seq.taxon = meta[0];
+        }
+        if (seq.taxon !== this.name) {
+            const otherSequence = this.inputStore.isoforms
+                .filter(isoform => isoform !== this)
+                .map(isoform => isoform.sequence)[0];
+            if (otherSequence?.taxon === seq.taxon) {
+                throw new Error(`Taxon '${seq.taxon}' in ${filename} have the same name as the other isoform.`)
+            }
+            // throw new Error(`Taxon '${seq.taxon}' in ${filename} doesn't match isoform name '${this.name}'.`)
+            this.setName(seq.taxon);
+        }
+        this.setSequence(seq);
+    });
+
+
+    setNetworkFile = action(async (file: NetworkFile) => {
+        this.netFile = file;
+
+        await this.runInfomap();
+
+        await this.generateNetwork();
+    })
+
+    setArgs = action((args: Arguments) => {
+        this.infomapArgs = { ...this.infomapArgs, ...args };
+    })
+
+    setProgress = action((progress: number) => { this.infomap.progress = progress })
+
+    generateNetwork = action(async () => {
+        if (this.netFile === null) {
+            return;
+        }
+
+        const nodes = this.netFile.nodes.map(({ id, name, path }) => {
+            return {
+                id: `${id}`,
+                label: name!,
+                path: typeof path === 'string' ? path : path.join(':')
+            };
+        });
+
+        const edgeHeading = "*Edges"
+        const lines = this.netFile.network?.split('\n');
+        let isEdge = false;
+        const links = [];
+        for (const line of lines ?? []) {
+            if (line[0] === '#' || line.length === 0) continue;
+            if (line[0] === '*') {
+                if (line.substring(0, edgeHeading.length) === edgeHeading) {
+                    isEdge = true;
+                    continue;
+                }
+            };
+            if (isEdge) {
+                let e = line.split(" ");//.map(value => Number(value));
+                links.push({ source: e[0], target: e[1], id: `${links.length}` })
+            }
+        }
+
+        this.network = {
+            nodes,
+            links
+        };
+    })
+
+    runInfomap = action(async () => {
+
+        if (this.netFile === null || this.infomap.isRunning) {
+            return;
+        }
+
+        runInAction(() => {
+            this.infomap.finished = false;
+            this.infomap.progress = 0;
+            this.infomap.isRunning = true;
+            this.infomap.error = "";
+        })
+
+        const netFile = await runInfomap({
+            network: this.netFile.network!,
+            filename: this.netFile.name,
+            args: this.infomapArgs,
+            onProgress: this.setProgress,
+            onError: (msg) => this.addError({ title: `Infomap error in isoform ${this.name}`, description: msg }),
+        })
+
+        runInAction(() => {
+            this.infomap.finished = true;
+            this.infomap.progress = 0;
+            this.infomap.isRunning = false;
+            this.netFile = netFile;
+        })
+    })
+
+}

--- a/src/store/PdbStore.ts
+++ b/src/store/PdbStore.ts
@@ -1,0 +1,574 @@
+import { action, computed, makeObservable, observable, runInAction } from "mobx";
+import type InputStore from "./InputStore"
+import { parseAcceptedFiles, setIdentifiers } from "../components/LoadNetworks/utils";
+import { NetworkFile } from "../components/LoadNetworks";
+import { parse, parseTree } from "@mapequation/infomap-parser";
+import Infomap from "@mapequation/infomap";
+import { Arguments } from "@mapequation/infomap/arguments";
+import { calcStatistics } from "../components/LoadNetworks/utils"
+import IsoformStore from "./IsoformStore";
+import { runInfomap } from "../utils/infomap";
+import { ErrorItem } from "./InputStore";
+import { mean } from "d3";
+
+const aaMap = new Map([
+    ["ALA", "A"], ["ARG", "R"], ["ASN", "N"], ["ASP", "D"], ["CYS", "C"], ["GLN", "Q"], ["GLU", "E"], ["GLY", "G"], ["HIS", "H"],
+    ["ILE", "I"], ["LEU", "L"], ["LYS", "K"], ["MET", "M"], ["PHE", "F"], ["PRO", "P"], ["SER", "S"], ["THR", "T"], ["TRP", "W"],
+    ["TYR", "Y"], ["VAL", "V"],
+    ["ASX", "B"],
+    ["GLX", "Z"]
+]);
+export const aaCharToName = new Map([...aaMap].map(([key, value]) => [value, key]));
+
+const BLUE = "rgb(128, 160, 240)";
+const RED = "rgb(240, 21, 5)";
+const MAGENTA = "rgb(192, 72, 192)";
+const GREEN = "rgb(21, 192, 21)";
+const PINK = "rgb(240, 128, 128)";
+const ORANGE = "rgb(240, 144, 72)";
+const YELLOW = "rgb(192, 192, 0)";
+const CYAN = "rgb(21, 164, 164)";
+const WHITE = "rgb(255,255,255)";
+
+
+// https://www.jalview.org/help/html/colourSchemes/clustal.html
+const aaColorsClustal = [
+    { category: "Hydrophobic", color: BLUE, residues: ["A", "I", "L", "M", "F", "W", "V", "C"] },
+    { category: "Positive charge", color: RED, residues: ["K", "R"] },
+    { category: "Negative charge", color: MAGENTA, residues: ["E", "D"] },
+    { category: "Polar", color: GREEN, residues: ["N", "Q", "S", "T"] },
+    { category: "Cysteines", color: PINK, residues: ["C"] },
+    { category: "Glycines", color: ORANGE, residues: ["G"] },
+    { category: "Prolines", color: YELLOW, residues: ["P"] },
+    { category: "Aromatic", color: CYAN, residues: ["H", "Y"] },
+    { category: "Unconserved", color: WHITE, residues: ["*"] },
+];
+
+const aaColorMap = new Map(aaColorsClustal.flatMap(item => item.residues.map(r => [r, item.color])))
+
+
+export const getAAColor = (code: string) => aaColorMap.get(code)!;
+
+type Coord = [number, number, number];
+
+type PdbItem = {
+    pos: number;
+    aa: string;
+    coords: [Coord, ...Coord[]]; // Minimum one coordinate
+    confidences: number[];
+}
+
+export type IsoformNode = {
+    index: number;
+    id: string;
+    label: string;
+    color: string;
+    pdbItem: PdbItem;
+    module?: number;
+    fx?: number;
+    fy?: number;
+    fz?: number;
+    confidence: number;
+}
+
+export type IsoformLink = {
+    sourceId: string;
+    targetId: string;
+    weight: number;
+    id?: string;
+    source?: IsoformNode,
+    target?: IsoformNode,
+}
+
+export type IsoformNetwork = {
+    nodes: IsoformNode[];
+    links: IsoformLink[];
+}
+
+type FilesByExt = {
+    "fasta": File[],
+    "pdb": File[],
+    "net": File[],
+}
+
+
+export default class PdbStore {
+    isoformStore: IsoformStore;
+
+    isLoading = false;
+
+    numDatasets = 0;
+    data = new Map<number, PdbItem>(); // pos -> PdbItem
+
+    linkDistanceThreshold = 7;
+
+    network: IsoformNetwork = {
+        nodes: [],
+        links: [],
+    }
+
+    netFile: NetworkFile | null = null;
+
+    infomap = {
+        progress: 0,
+        isRunning: false,
+        error: "",
+        finished: false,
+    }
+
+    infomapArgs: Arguments = {
+        numTrials: 20,
+        output: "tree",
+    }
+
+    errors: ErrorItem[] = [];
+
+    constructor(isoformStore: IsoformStore) {
+        this.isoformStore = isoformStore;
+        makeObservable(this, {
+            isLoading: observable,
+            linkDistanceThreshold: observable,
+            numDatasets: observable,
+            netFile: observable.ref,
+            network: observable.ref,
+            infomapArgs: observable,
+            infomap: observable,
+            selectedIndex: observable,
+            content: observable,
+            error: observable,
+            haveModules: computed,
+            haveNetwork: computed,
+        });
+    }
+
+    content: string = "";
+    setContent = action((content: string) => {
+        this.content = content;
+    })
+
+    error: string = "";
+
+    selectedIndex = 0;
+    setSelectedIndex = action((value: number) => {
+        if (value >= 0 && value < this.numDatasets && value !== this.selectedIndex) {
+            this.selectedIndex = value;
+            this.updateNodePositions();
+            // this.generateNetwork();
+        }
+    })
+
+    clear = action(() => {
+        this.isLoading = false;
+        this.numDatasets = 0;
+        this.selectedIndex = 0;
+        this.data = new Map<number, PdbItem>();
+        this.netFile = null;
+        this.errors = [];
+        this.error = "";
+        this.content = "";
+
+        this.clearNetwork();
+        this.clearInfomap();
+
+        this.isoformStore.sequence = null;
+    })
+
+    clearNetwork = action(() => {
+        this.network = {
+            nodes: [],
+            links: []
+        }
+    })
+
+    clearInfomap = action(() => {
+        this.infomap = {
+            progress: 0,
+            isRunning: false,
+            error: "",
+            finished: false,
+        }
+    })
+
+    get name() {
+        return this.isoformStore.name;
+    }
+
+    get haveNetwork() {
+        return this.network.nodes.length > 0;
+    }
+
+    get haveModules() {
+        return this.netFile?.haveModules;
+    }
+
+    addError = action((error: ErrorItem) => {
+        this.errors.push(error);
+    })
+
+    setArgs = action((args: Arguments) => {
+        this.infomapArgs = { ...this.infomapArgs, ...args };
+    })
+
+    setLinkDistanceThreshold = action((value: number) => {
+        this.linkDistanceThreshold = value;
+        this.generateNetwork();
+    })
+
+    /**
+     * Parse AlphaFold .pdb file.
+     * 
+     * Sample line:
+     * ATOM      5  CA  MET A   1     -28.333  28.626  28.646  1.00 42.15           C  
+     *                  aa      pos   x        y       z
+     * 
+     * ATOM  15405  CA  MET A1000     -62.658  29.837  48.709  1.00 91.15           C  
+     * 
+     * @param file: File The pdb file.
+     */
+    parsePdbFile = async (file: File) => {
+        const content = await file.text();
+        await this.loadPdbContent(content);
+    };
+
+    loadFiles = async (files: File[]) => {
+        this.isLoading = true;
+        await Promise.all(files.map(this.parsePdbFile));
+        this.isLoading = false;
+    }
+
+    loadPdbContent = action(async (content: string) => {
+        try {
+            await this.parsePdbContent(content);
+            this.error = "";
+            this.setContent("");
+        } catch (e: any) {
+            this.error = e.message;
+            console.error("Error loading pdb content:", e.message);
+            this.addError({
+                title: "PDB loading error",
+                description: e.message,
+            });
+        }
+    })
+
+    /**
+     * PDB file format:
+     * 
+Contains:	the atomic coordinates for standard residues and the occupancy and temperature factor for each atom
+
+COLUMNS        DATA TYPE       CONTENTS                            
+--------------------------------------------------------------------------------
+ 1 -  6        Record name     "ATOM  "                                            
+ 7 - 11        Integer         Atom serial number.                   
+13 - 16        Atom            Atom name.                            
+17             Character       Alternate location indicator.         
+18 - 20        Residue name    Residue name.                         
+22             Character       Chain identifier.                     
+23 - 26        Integer         Residue sequence number.              
+27             AChar           Code for insertion of residues.       
+31 - 38        Real(8.3)       Orthogonal coordinates for X in Angstroms.                       
+39 - 46        Real(8.3)       Orthogonal coordinates for Y in Angstroms.                            
+47 - 54        Real(8.3)       Orthogonal coordinates for Z in Angstroms.                            
+55 - 60        Real(6.2)       Occupancy.                            
+61 - 66        Real(6.2)       Temperature factor (Default = 0.0).                   
+73 - 76        LString(4)      Segment identifier, left-justified.   
+77 - 78        LString(2)      Element symbol, right-justified.      
+79 - 80        LString(2)      Charge on the atom.       
+
+Example: 
+
+         1         2         3         4         5         6         7         8
+12345678901234567890123456789012345678901234567890123456789012345678901234567890
+ATOM    145  N   VAL A  25      32.433  16.336  57.540  1.00 11.92      A1   N
+ATOM    146  CA  VAL A  25      31.132  16.439  58.160  1.00 11.85      A1   C
+ATOM    147  C   VAL A  25      30.447  15.105  58.363  1.00 12.34      A1   C
+ATOM    148  O   VAL A  25      29.520  15.059  59.174  1.00 15.65      A1   O
+ATOM    149  CB AVAL A  25      30.385  17.437  57.230  0.28 13.88      A1   C
+ATOM    150  CB BVAL A  25      30.166  17.399  57.373  0.72 15.41      A1   C
+     * 
+     * 
+     * @param content .pdb file content
+     * @param filename optional filename for error messages
+     */
+    parsePdbContent = async (content: string, filename?: string) => {
+        if (filename === undefined) {
+            filename = "loaded content"
+        }
+        const lines = content.split("\n");
+        for (let i = 0; i < lines.length; ++i) {
+            const line = lines[i];
+            if (line.substring(0, 4) !== "ATOM") {
+                continue;
+            }
+            if (line.length < 66) {
+                throw Error(`Line ${i + 1} (${line}) of ${filename} doesn't match the format for ATOM records.`);
+            }
+
+            const atom = line.substring(12, 16).trim();
+            if (atom !== "CA") {
+                continue;
+            }
+            const residue = line.substring(17, 20).trim();
+            const aa = aaMap.get(residue)!;
+            const pos = Number(line.substring(22, 26).trim());
+            const x = Number(line.substring(30, 38).trim());
+            const y = Number(line.substring(38, 46).trim());
+            const z = Number(line.substring(46, 54).trim());
+            const confidence = Number(line.substring(60, 66).trim());
+
+            if (pos < 0 || pos !== Math.round(pos)) {
+                throw Error(`Position ${pos} not valid in line '${line}' of ${filename}.`)
+            }
+
+            if (this.numDatasets === 0) {
+                this.data.set(pos, { aa, pos, coords: [[x, y, z]], confidences: [confidence] })
+            }
+            else {
+                const item = this.data.get(pos);
+                if (item === undefined) {
+                    throw Error(`Position ${pos} in dataset ${this.numDatasets + 1} does not exist in previous.`)
+                }
+                if (aa !== item.aa) {
+                    throw Error(`Aminoacid '${aa}' in pos ${pos} in dataset ${this.numDatasets + 1} does not match '${item.aa}' in previous dataset`);
+                }
+                item.coords.push([x, y, z]);
+                item.confidences.push(confidence);
+            }
+        }
+        // console.log("pdb parsed data:", this.data)
+        runInAction(() => {
+            this.numDatasets = this.numDatasets + 1;
+            if (this.numDatasets === 1) {
+                const seq = {
+                    taxon: this.isoformStore.name,
+                    code: Array.from(this.data, ([_, item]) => item.aa).join(""),
+                }
+                this.isoformStore.setSequence(seq);
+            }
+            this.generateNetwork();
+        })
+    }
+
+    parsePdbFiles = async (files: File[], runInfomap = false) => {
+        console.log(`Parse pdb files: ${files.map(file => file.name)}`)
+        await Promise.all(files.map(file => this.parsePdbFile(file)));
+
+        if (runInfomap && this.numDatasets > 0) {
+            this.generateNetwork();
+            await this.runInfomap();
+        }
+    }
+
+    getNodeLabel(item: PdbItem) {
+        return this.isoformStore.alignmentMap?.get(item.pos) ?? `${item.pos}_${item.aa}`;
+    }
+
+    updateNodes() {
+        console.log("Update nodes...");
+        this.network.nodes = this.network.nodes.map((node, i) => {
+            const item = this.data.get(i + 1)!;
+            const [fx, fy, fz] = item.coords[this.selectedIndex];
+            return {
+                ...node,
+                label: this.getNodeLabel(item),
+                fx, fy, fz,
+            };
+        });
+        return this.network.nodes;
+    }
+
+    getNodes() {
+        const nodes: IsoformNode[] = this.network.nodes;
+        if (nodes.length > 0) {
+            return this.updateNodes();
+        }
+
+        this.data.forEach((item, index) => {
+            const [fx, fy, fz] = item.coords[this.selectedIndex];
+            const confidence = mean(item.confidences)!;
+            nodes.push({
+                index,
+                id: `${item.pos}`,
+                label: this.getNodeLabel(item),
+                color: aaColorMap.get(item.aa)!,
+                pdbItem: item,
+                fx, fy, fz,
+                confidence,
+            })
+        });
+        return nodes;
+    }
+
+    updateLinks() {
+        const { nodes, links } = this.network;
+        this.network.links = links.map(link => {
+            return {
+                ...link,
+                source: nodes[link.source!.index],
+                target: nodes[link.target!.index],
+            }
+        });
+        return this.network.links;
+    }
+
+    updateNodePositions = action(() => {
+        this.network = {
+            nodes: this.getNodes(),
+            links: this.updateLinks(),
+        }
+    })
+
+    generateNetwork = action(() => {
+        console.log(`[PdbStore]: generateNetwork with threshold ${this.linkDistanceThreshold}...`)
+        const nodes = this.getNodes();
+
+        const calcDistanceSquared = (p1: Coord, p2: Coord) => {
+            const d = [p2[0] - p1[0], p2[1] - p1[1], p2[2] - p1[2]];
+            return d[0] * d[0] + d[1] * d[1] + d[2] * d[2];
+        }
+
+        // Pairwise distances
+        const threshold = this.linkDistanceThreshold ** 2;
+        const items = Array.from(this.data.values());
+        const links: IsoformLink[] = [];
+        for (let i = 0; i < items.length; ++i) {
+            const p1 = items[i];
+            for (let j = i + 1; j < items.length; ++j) {
+                const p2 = items[j];
+                let weight = 0;
+                for (let k = 0; k < this.numDatasets; ++k) {
+                    const d2 = calcDistanceSquared(p1.coords[k], p2.coords[k]);
+                    if (d2 <= threshold) {
+                        weight += 1
+                    }
+                }
+                if (weight > 0) {
+                    links.push({ sourceId: `${p1.pos}`, targetId: `${p2.pos}`, weight: weight / this.numDatasets })
+                }
+            }
+        }
+        // console.log(`!!! Generated network with ${nodes.length} nodes and ${links.length} links!`)
+
+        this.network = {
+            nodes,
+            links,
+        };
+    })
+
+    setProgress = action((progress: number) => { this.infomap.progress = progress })
+
+    isInsignificantValue(confidence: number) {
+        return confidence < 70;
+    }
+
+    isInsignificant(node: IsoformNode) {
+        return this.isInsignificantValue(node.confidence);
+    }
+
+    getModuleColor(module?: number) {
+        const defaultColor = "#cccccc";
+        if (!module) return defaultColor;
+        return this.isoformStore.inputStore.rootStore.getHighlightColor(module - 1) ?? defaultColor;
+    }
+
+    updateColor = action((by: "node" | "module") => {
+        if (by === "node") {
+            this.network.nodes.forEach(node => {
+                node.color = aaColorMap.get(node.label)!;
+            })
+        } else {
+            this.network.nodes.forEach(node => {
+                const color = this.getModuleColor(node.module);
+                node.color = color;
+            })
+        }
+        this.updateNetwork();
+    })
+
+    updateNetwork = action(() => {
+        this.network = { ...this.network };
+    })
+
+    serializeNetwork = () => {
+        console.log("Serialize network...");
+        const { nodes, links } = this.network;
+
+        // const getId = links.length > 0 && typeof links[0].source !== 'string' ? ((v: { id: string }) => v.id) : (v: string) => v;
+
+        const lines: string[] = [];
+        lines.push(`*Vertices ${nodes.length}`);
+        nodes.forEach(node => {
+            lines.push(`${node.id} "${node.label}"`);
+        })
+        lines.push(`*Edges ${links.length}`);
+        links.forEach(link => {
+            //@ts-ignore
+            // console.log(`${getId(link.source)} ${getId(link.target)}`, link);
+            //@ts-ignore
+            lines.push(`${link.sourceId} ${link.targetId} ${link.weight}`);
+        })
+        // console.log(lines)
+        return lines.join('\n');
+    }
+
+    runInfomap = action(async () => {
+        console.time("[PdbStore]: runInfomap")
+        console.log("[PdbStore]: runInfomap")
+        if (this.infomap.isRunning) {
+            return;
+        }
+
+        if (this.network.nodes.length === 0) {
+            return;
+        }
+
+        const network = this.serializeNetwork();
+
+        runInAction(() => {
+            this.infomap.finished = false;
+            this.infomap.progress = 0;
+            this.infomap.isRunning = true;
+            this.infomap.error = "";
+        })
+
+        const netFile = await runInfomap({
+            network,
+            filename: `${this.name}.net`,
+            args: this.infomapArgs,
+            onProgress: this.setProgress,
+            onError: (msg) => this.addError({ title: `Infomap error in isoform ${this.name}`, description: msg }),
+        })
+
+        const modules = new Map<string, number>();
+
+        const confidenceMap = new Map<string, number>();
+        this.network.nodes.forEach(node => {
+            confidenceMap.set(node.id, node.confidence);
+        })
+
+        console.log(`Infomap result for '${this.name}':`, netFile);
+
+        netFile.nodes.forEach((node) => {
+            const path = Array.isArray(node.path) ? node.path : node.path?.split(":") ?? [];
+            const topModule = Number(path[0]);
+            modules.set(`${node.id}`, topModule);
+            if (this.isInsignificantValue(confidenceMap.get(`${node.id}`)!)) {
+                node.path = path.join(";") + ";";
+            }
+        })
+
+        this.network.nodes.forEach(node => {
+            node.module = modules.get(node.id);
+        })
+
+        this.updateColor("module")
+
+        runInAction(() => {
+            this.infomap.finished = true;
+            this.infomap.progress = 0;
+            this.infomap.isRunning = false;
+            this.netFile = netFile;
+        })
+        console.timeEnd("[PdbStore]: runInfomap")
+    })
+}

--- a/src/store/Store.ts
+++ b/src/store/Store.ts
@@ -20,13 +20,15 @@ import type { NetworkFile } from "../components/LoadNetworks";
 import type { Histogram } from "../components/Sidebar/Metadata/Real";
 import TreePath from "../utils/TreePath";
 import BipartiteGraph from "./BipartiteGraph";
+import InputStore from "./InputStore";
 import { COLOR_SCHEMES, ColorScheme, SchemeName } from "./schemes";
 
 export class Store {
+  input: InputStore;
   diagram = new Diagram();
 
   files: NetworkFile[] = [];
-  identifier: Identifier = "id";
+  identifier: Identifier = "name";
 
   // hack to force updates when we call updateLayout
   updateFlag = true;
@@ -43,8 +45,8 @@ export class Store {
   streamlineOpacity: number = 0.8;
   flowThreshold: number = 5e-3;
 
-  selectedScheme: ColorScheme = COLOR_SCHEMES["C3 Sinebow"];
-  selectedSchemeName: SchemeName = "C3 Sinebow";
+  selectedScheme: ColorScheme = COLOR_SCHEMES["C3 Turbo"];
+  selectedSchemeName: SchemeName = "C3 Turbo";
 
   defaultHighlightColor: string = "#b6b69f";
   highlightColors: string[] = [...this.selectedScheme];
@@ -53,7 +55,7 @@ export class Store {
   moduleSize: ModuleSize = "flow";
   sortModulesBy: ModuleOrder = "flow";
 
-  showModuleId: boolean = false;
+  showModuleId: boolean = true;
   showModuleNames: boolean = true;
   multilineModuleNames: boolean = true;
   showNetworkNames: boolean = true;
@@ -115,6 +117,7 @@ export class Store {
       editMode: observable,
       showBipartiteNodes: observable,
     });
+    this.input = new InputStore(this);
   }
 
   private checkColors(networks: any[]) {
@@ -163,6 +166,12 @@ export class Store {
     if (selectLargest) {
       this.setSelectedModule(this.diagram.children[0]?.children[0]);
     }
+
+    this.colorNodesInModulesInAllNetworks(undefined);
+
+    setTimeout(() => {
+      this.setSelectedModule(null);
+    }, 100);
 
     console.timeEnd("Store.setNetworks");
   });
@@ -838,6 +847,9 @@ export class Store {
   }
 
   updateLayout() {
+    if (this.numNetworks === 0) {
+      return;
+    }
     this.diagram.calcFlow();
     this.diagram.updateLayout(this);
     this.toggleUpdate();

--- a/src/theme.tsx
+++ b/src/theme.tsx
@@ -4,6 +4,21 @@ import { createSystem, defaultConfig, defineConfig } from "@chakra-ui/react";
 // default blue is Tailwind-style (#3b82f6 at 500), which reads slightly
 // cooler and less saturated than the mapequation brand blue.
 const config = defineConfig({
+  globalCss: {
+    // Chakra v3's solid Button hover is `colorPalette.solid/90` (90% alpha of
+    // the resting bg). With our remap of `gray.solid` to the v2 light-gray
+    // (gray.100), that alpha-blend is visually identical to the rest state on
+    // a light page — buttons look dead. Define explicit hover/active steps
+    // here. `!important` is needed because Chakra puts globalCss into the
+    // `base` cascade layer and the variant's hover rule lives in `recipes`,
+    // which comes after `base` in the layer order — recipes wins without it.
+    ".chakra-button:not(:disabled, [data-disabled]):is(:hover, [data-hover])": {
+      bg: "gray.200 !important",
+    },
+    ".chakra-button:not(:disabled, [data-disabled]):active": {
+      bg: "gray.300 !important",
+    },
+  },
   theme: {
     tokens: {
       colors: {
@@ -19,6 +34,37 @@ const config = defineConfig({
           800: { value: "#2a4365" },
           900: { value: "#1a365d" },
           950: { value: "#142a4a" },
+        },
+      },
+    },
+    // Chakra v3's default gray solid Button is near-black (gray.800 bg, white
+    // text). v2 rendered the default gray Button as a light gray pill
+    // (gray.100 bg, gray.800 text). Remap gray's solid/contrast semantic
+    // tokens to that v2 treatment so unstyled Buttons read as neutral
+    // affordances, not heavy primary CTAs.
+    semanticTokens: {
+      colors: {
+        gray: {
+          solid: {
+            value: { _light: "{colors.gray.100}", _dark: "{colors.gray.700}" },
+          },
+          contrast: {
+            value: { _light: "{colors.gray.800}", _dark: "{colors.gray.100}" },
+          },
+        },
+      },
+    },
+    // Default `layerStyle: "disabled"` is just opacity 0.5; on a solid button
+    // that still reads as a pressable CTA. Flatten the bg to neutral so the
+    // disabled state clearly cannot be pressed.
+    layerStyles: {
+      disabled: {
+        value: {
+          bg: "gray.50",
+          color: "gray.400",
+          borderColor: "gray.100",
+          cursor: "not-allowed",
+          opacity: 1,
         },
       },
     },

--- a/src/utils/infomap.ts
+++ b/src/utils/infomap.ts
@@ -1,0 +1,58 @@
+import Infomap from "@mapequation/infomap";
+import { parseTree } from "@mapequation/infomap-parser";
+import { Arguments } from "@mapequation/infomap/arguments";
+import { setIdentifiers, createFile } from "../components/LoadNetworks/utils";
+import { NetworkFile } from "../components/LoadNetworks";
+import { Identifier } from "../alluvial";
+
+type RunInfomapData = {
+    network: string;
+    filename: string;
+    onProgress?: (value: number) => void;
+    onError?: (message: string) => void;
+    args?: Arguments;
+    identifier?: Identifier;
+}
+
+export async function runInfomap(data: RunInfomapData): Promise<NetworkFile> {
+    const infomap = new Infomap();
+    console.time(`Infomap on '${data.filename}'`);
+
+    const { onProgress, onError } = data;
+
+    if (onProgress) {
+        infomap.on("progress", onProgress);
+    }
+    if (onError !== undefined) {
+        infomap.on("error", (error) => {
+            const message = error.replace(/^Error:\s+/i, "");
+            onError(message);
+        })
+    }
+
+    const filename = data.filename;
+    const result = await infomap.runAsync({
+        network: data.network,
+        filename,
+        args: data.args,
+    });
+
+    const tree = result.tree_states || result.tree || result.tree_states || result.tree;
+
+    if (!tree) {
+        throw new Error("No tree output from Infomap");
+    }
+
+    const contents = parseTree(tree, undefined, false, true);
+    setIdentifiers(contents.nodes, "tree", data.identifier ?? "name");
+
+    const file = new File([data.network], filename, { type: "text/plain" });
+
+    const newFile = createFile(file, "net", contents);
+
+    newFile.twoLevel = data.args?.twoLevel;
+    newFile.numTrials = data.args?.numTrials;
+
+    console.timeEnd(`Infomap on '${data.filename}'`);
+    return newFile;
+}

--- a/src/utils/pluralize.ts
+++ b/src/utils/pluralize.ts
@@ -1,0 +1,4 @@
+
+export default function pluralize(num: number, noun: string) {
+    return `${num} ${num !== 1 ? noun + "s" : noun}`;
+}

--- a/src/utils/sequence-parser.ts
+++ b/src/utils/sequence-parser.ts
@@ -1,0 +1,90 @@
+
+export type Sequence = { taxon: string, code: string }
+
+export const isFasta = (lines: string[]) => {
+    for (let i = 0; i < lines.length; ++i) {
+        const line = lines[0].trim();
+        if (line.length === 0 || line[0] === '#') {
+            continue;
+        }
+        if (line[0] === '>') {
+            return true;
+        }
+    }
+    return false;
+}
+
+export const parseFasta = (lines: string[]) => {
+
+    if (!isFasta(lines)) {
+        throw new Error(`Could not parse the file as a FASTA file`);
+    }
+
+    let lineIndex = 0;
+
+    const parseTaxon = (line: string) => {
+        if (line[0] !== '>') {
+            throw new Error(`Expected a '>' to start a taxon line`);
+        }
+        const taxon = line.substring(1);
+        if (!taxon) {
+            throw new Error(`Empty taxon at line ${lineIndex + 1}`);
+        }
+        return taxon;
+    }
+    const parseCode = (line: string) => {
+        const code = line.replace(/\s+/g, '');
+        if (!code) {
+            throw new Error(`Empty sequence at line ${lineIndex + 1}`);
+        }
+        return code;
+    }
+
+    const sequences: Sequence[] = [];
+    let taxon = '';
+    let codeLines: string[] = [];
+
+    const addSequence = () => {
+        const code = codeLines.join('');
+        sequences.push({ taxon, code });
+        codeLines = [];
+    }
+
+    for (; lineIndex < lines.length; ++lineIndex) {
+        const line = lines[lineIndex];
+        if (line.length === 0 || line[0] === '#') {
+            continue;
+        }
+        if (line[0] === '>') {
+            if (taxon) {
+                addSequence();
+                codeLines = [];
+            }
+            taxon = parseTaxon(line);
+        }
+        else {
+            if (!taxon) {
+                throw new Error(`'No taxon line found before line ${lineIndex + 1} ('${line}')`);
+            }
+            codeLines.push(parseCode(line));
+        }
+    }
+    addSequence();
+
+    // const numSequences = sequences.length;
+
+    // console.log('Sequences:', sequences);
+    // const alignment = {
+    //     sequences,
+    //     numSequences,
+    //     fileFormat: 'FASTA',
+    // };
+
+    return sequences;
+
+}
+
+export default {
+    isFasta,
+    parseFasta,
+};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,7 +6,7 @@ const config: UserConfig & {
   test?: { environment: string; globals: boolean; setupFiles: string[], include: string[]; exclude: string[] };
 } = {
   plugins: [react()],
-  base: "/alluvial/",
+  base: "/isoformmapper/",
   build: {
     outDir: "build",
     sourcemap: true,


### PR DESCRIPTION
Reapply the IsoformMapper-specific code on top of the upstream alluvial master after the vite + Chakra v3 migration. The previous 30-commit history against react-scripts + Chakra v2 is preserved on the `backup/isoformmapper-pre-rebase` branch — it was collapsed into this one commit because every step would have needed Chakra v3 adaptations to compile cleanly.

- Bring in src/components/isoform/* (DropData, AlignSequences, PartitionNetworks, IsoformAlluvialDiagram, NetworkInfo, Progress, SequenceView, StepHeading, Graph, LoadData, InputTextArea, FileInput, IsoformApp), src/store/{Input,Isoform,Pdb}Store.ts, and supporting utils (sequence-parser, infomap, pluralize, General/SelectButtonGroup).
- Port IsoformMapper-specific tweaks to shared files: App.tsx renders <IsoformApp /> instead of <Diagram />, Store.ts gains input: InputStore and v2-style defaults (C3 Turbo, name identifier, auto-color after setNetworks), Diagram.tsx accepts optional width/height for embedding in IsoformAlluvialDiagram, Logo shows "IsoformMapper" with the Infomap version, index.css drops body { overflow: hidden } so the scroll layout works.
- Theme: remap gray.solid / gray.contrast to v2's light-gray pill (gray.100 bg, gray.800 text), restore a meaningful Button hover step (gray.200 via globalCss with !important to clear Chakra's recipes cascade layer), and flatten the disabled layerStyle.
- Restyle the alluvial Tooltip to a light surface with a hairline border so it stops reading as a dark slab against the white inner chart panel.
- Add dependencies: biomsa, react-force-graph-3d.
- vite.config.ts base is now /isoformmapper/; package name is isoformmapper.